### PR TITLE
chore: regenerate sdk

### DIFF
--- a/Appwrite/Appwrite.csproj
+++ b/Appwrite/Appwrite.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageId>Appwrite</PackageId>
-    <Version>0.13.0</Version>
+    <Version>0.14.0</Version>
     <Authors>Appwrite Team</Authors>
     <Company>Appwrite Team</Company>
     <Description>
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <None Include="..\icon.png" Pack="true" PackagePath="$(PackageIcon)"/>
     <None Include="..\README.md" Pack="true" PackagePath="$(PackageReadmeFile)"/>

--- a/Appwrite/Client.cs
+++ b/Appwrite/Client.cs
@@ -1,7 +1,3 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,6 +5,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Appwrite.Converters;
 using Appwrite.Extensions;
@@ -29,26 +27,28 @@ namespace Appwrite
 
         private static readonly int ChunkSize = 5 * 1024 * 1024;
 
-        public static JsonSerializerSettings DeserializerSettings { get; set; } = new JsonSerializerSettings
+        public static JsonSerializerOptions DeserializerOptions { get; set; } = new JsonSerializerOptions
         {
-            MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
-            NullValueHandling = NullValueHandling.Ignore,
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
-            Converters = new List<JsonConverter>
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNameCaseInsensitive = true,
+            Converters =
             {
-                new StringEnumConverter(new CamelCaseNamingStrategy()),
-                new ValueClassConverter()
+                new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
+                new ValueClassConverter(),
+                new ObjectToInferredTypesConverter()
             }
         };
 
-        public static JsonSerializerSettings SerializerSettings { get; set; } = new JsonSerializerSettings
+        public static JsonSerializerOptions SerializerOptions { get; set; } = new JsonSerializerOptions
         {
-            NullValueHandling = NullValueHandling.Ignore,
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
-            Converters = new List<JsonConverter>
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters =
             {
-                new StringEnumConverter(new CamelCaseNamingStrategy()),
-                new ValueClassConverter()
+                new JsonStringEnumConverter(JsonNamingPolicy.CamelCase),
+                new ValueClassConverter(),
+                new ObjectToInferredTypesConverter()
             }
         };
 
@@ -69,11 +69,12 @@ namespace Appwrite
             _headers = new Dictionary<string, string>()
             {
                 { "content-type", "application/json" },
-                { "user-agent" , "AppwriteDotNetSDK/0.13.0 (${Environment.OSVersion.Platform}; ${Environment.OSVersion.VersionString})"},
+                { "user-agent" , $"AppwriteDotNetSDK/0.14.0 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
                 { "x-sdk-name", ".NET" },
                 { "x-sdk-platform", "server" },
                 { "x-sdk-language", "dotnet" },
-                { "x-sdk-version", "0.13.0"},                { "X-Appwrite-Response-Format", "1.7.0" }
+                { "x-sdk-version", "0.14.0"},
+                { "X-Appwrite-Response-Format", "1.7.0" }
             };
 
             _config = new Dictionary<string, string>();
@@ -82,8 +83,6 @@ namespace Appwrite
             {
                 SetSelfSigned(true);
             }
-
-            JsonConvert.DefaultSettings = () => DeserializerSettings;
         }
 
         public Client SetSelfSigned(bool selfSigned)
@@ -189,19 +188,23 @@ namespace Appwrite
                 {
                     if (parameter.Key == "file")
                     {
-                        form.Add(((MultipartFormDataContent)parameters["file"]).First()!);
+                        var fileContent = parameters["file"] as MultipartFormDataContent;
+                        if (fileContent != null)
+                        {
+                            form.Add(fileContent.First()!);
+                        }
                     }
                     else if (parameter.Value is IEnumerable<object> enumerable)
                     {
                         var list = new List<object>(enumerable);
                         for (int index = 0; index < list.Count; index++)
                         {
-                            form.Add(new StringContent(list[index].ToString()!), $"{parameter.Key}[{index}]");
+                            form.Add(new StringContent(list[index]?.ToString() ?? string.Empty), $"{parameter.Key}[{index}]");
                         }
                     }
                     else
                     {
-                        form.Add(new StringContent(parameter.Value.ToString()!), parameter.Key);
+                        form.Add(new StringContent(parameter.Value?.ToString() ?? string.Empty), parameter.Key);
                     }
                 }
                 request.Content = form;
@@ -274,8 +277,19 @@ namespace Appwrite
                 }
 
                 if (contentType.Contains("application/json")) {
-                    message = JObject.Parse(text)["message"]!.ToString();
-                    type = JObject.Parse(text)["type"]?.ToString() ?? string.Empty;
+                    try 
+                    {
+                        using var errorDoc = JsonDocument.Parse(text);
+                        message = errorDoc.RootElement.GetProperty("message").GetString() ?? "";
+                        if (errorDoc.RootElement.TryGetProperty("type", out var typeElement))
+                        {
+                            type = typeElement.GetString() ?? "";
+                        }
+                    }
+                    catch
+                    {
+                        message = text;
+                    }
                 } else {
                     message = text;
                 }
@@ -283,7 +297,7 @@ namespace Appwrite
                 throw new AppwriteException(message, code, type, text);
             }
 
-            return response.Headers.Location.OriginalString;
+            return response.Headers.Location?.OriginalString ?? string.Empty;
         }
 
         public Task<Dictionary<string, object?>> Call(
@@ -329,8 +343,19 @@ namespace Appwrite
                 var type = "";
 
                 if (isJson) {
-                    message = JObject.Parse(text)["message"]!.ToString();
-                    type = JObject.Parse(text)["type"]?.ToString() ?? string.Empty;
+                    try 
+                    {
+                        using var errorDoc = JsonDocument.Parse(text);
+                        message = errorDoc.RootElement.GetProperty("message").GetString() ?? "";
+                        if (errorDoc.RootElement.TryGetProperty("type", out var typeElement))
+                        {
+                            type = typeElement.GetString() ?? "";
+                        }
+                    }
+                    catch
+                    {
+                        message = text;
+                    }
                 } else {
                     message = text;
                 }
@@ -342,13 +367,13 @@ namespace Appwrite
             {
                 var responseString = await response.Content.ReadAsStringAsync();
 
-                var dict = JsonConvert.DeserializeObject<Dictionary<string, object>>(
+                var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(
                     responseString,
-                    DeserializerSettings);
+                    DeserializerOptions);
 
-                if (convert != null)
+                if (convert != null && dict != null)
                 {
-                    return convert(dict!);
+                    return convert(dict);
                 }
 
                 return (dict as T)!;
@@ -368,7 +393,16 @@ namespace Appwrite
             string? idParamName = null,
             Action<UploadProgress>? onProgress = null) where T : class
         {
+            if (string.IsNullOrEmpty(paramName))
+                throw new ArgumentException("Parameter name cannot be null or empty", nameof(paramName));
+                
+            if (!parameters.ContainsKey(paramName))
+                throw new ArgumentException($"Parameter {paramName} not found", nameof(paramName));
+                
             var input = parameters[paramName] as InputFile;
+            if (input == null)
+                throw new ArgumentException($"Parameter {paramName} must be an InputFile", nameof(paramName));
+                
             var size = 0L;
             switch(input.SourceType)
             {
@@ -378,10 +412,16 @@ namespace Appwrite
                     size = info.Length;
                     break;
                 case "stream":
-                    size = (input.Data as Stream).Length;
+                    var stream = input.Data as Stream;
+                    if (stream == null)
+                        throw new InvalidOperationException("Stream data is null");
+                    size = stream.Length;
                     break;
                 case "bytes":
-                    size = ((byte[])input.Data).Length;
+                    var bytes = input.Data as byte[];
+                    if (bytes == null)
+                        throw new InvalidOperationException("Byte array data is null");
+                    size = bytes.Length;
                     break;
             };
 
@@ -395,10 +435,16 @@ namespace Appwrite
                 {
                     case "path":
                     case "stream":
-                        await (input.Data as Stream).ReadAsync(buffer, 0, (int)size);
+                        var dataStream = input.Data as Stream;
+                        if (dataStream == null)
+                            throw new InvalidOperationException("Stream data is null");
+                        await dataStream.ReadAsync(buffer, 0, (int)size);
                         break;
                     case "bytes":
-                        buffer = (byte[])input.Data;
+                        var dataBytes = input.Data as byte[];
+                        if (dataBytes == null)
+                            throw new InvalidOperationException("Byte array data is null");
+                        buffer = dataBytes;
                         break;
                 }
 
@@ -424,14 +470,16 @@ namespace Appwrite
                 // Make a request to check if a file already exists
                 var current = await Call<Dictionary<string, object?>>(
                     method: "GET",
-                    path: $"{path}/{parameters[idParamName]}",
+                    path: $"{path}/{parameters[idParamName!]}",
                     new Dictionary<string, string> { { "content-type", "application/json" } },
                     parameters: new Dictionary<string, object?>()
                 );
-                var chunksUploaded = (long)current["chunksUploaded"];
-                offset = chunksUploaded * ChunkSize;
+                if (current.TryGetValue("chunksUploaded", out var chunksUploadedValue) && chunksUploadedValue != null)
+                {
+                    offset = Convert.ToInt64(chunksUploadedValue) * ChunkSize;
+                }
             }
-                catch (Exception ex)
+                catch
                 {
                     // ignored as it mostly means file not found
                 }
@@ -444,6 +492,8 @@ namespace Appwrite
                     case "path":
                     case "stream":
                         var stream = input.Data as Stream;
+                        if (stream == null)
+                            throw new InvalidOperationException("Stream data is null");
                         stream.Seek(offset, SeekOrigin.Begin);
                         await stream.ReadAsync(buffer, 0, ChunkSize);
                         break;
@@ -476,12 +526,12 @@ namespace Appwrite
                 var id = result.ContainsKey("$id")
                     ? result["$id"]?.ToString() ?? string.Empty
                     : string.Empty;
-                var chunksTotal = result.ContainsKey("chunksTotal")
-                    ? (long)result["chunksTotal"]
-                    : 0;
-                var chunksUploaded = result.ContainsKey("chunksUploaded")
-                    ? (long)result["chunksUploaded"]
-                    : 0;
+                var chunksTotal = result.TryGetValue("chunksTotal", out var chunksTotalValue) && chunksTotalValue != null
+                    ? Convert.ToInt64(chunksTotalValue)
+                    : 0L;
+                var chunksUploaded = result.TryGetValue("chunksUploaded", out var chunksUploadedValue) && chunksUploadedValue != null
+                    ? Convert.ToInt64(chunksUploadedValue)
+                    : 0L;
 
                 headers["x-appwrite-id"] = id;
 
@@ -494,7 +544,11 @@ namespace Appwrite
                         chunksUploaded: chunksUploaded));
             }
 
-            return converter(result);
+            // Convert to non-nullable dictionary for converter
+            var nonNullableResult = result.Where(kvp => kvp.Value != null)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!);
+            
+            return converter(nonNullableResult);
         }
     }
 }

--- a/Appwrite/Converters/ObjectToInferredTypesConverter.cs
+++ b/Appwrite/Converters/ObjectToInferredTypesConverter.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Appwrite.Converters
+{
+    public class ObjectToInferredTypesConverter : JsonConverter<object>
+    {
+        public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.True:
+                    return true;
+                case JsonTokenType.False:
+                    return false;
+                case JsonTokenType.Number:
+                    if (reader.TryGetInt64(out long l))
+                    {
+                        return l;
+                    }
+                    return reader.GetDouble();
+                case JsonTokenType.String:
+                    if (reader.TryGetDateTime(out DateTime datetime))
+                    {
+                        return datetime;
+                    }
+                    return reader.GetString()!;
+                case JsonTokenType.StartObject:
+                    return JsonSerializer.Deserialize<Dictionary<string, object>>(ref reader, options)!;
+                case JsonTokenType.StartArray:
+                    return JsonSerializer.Deserialize<object[]>(ref reader, options)!;
+                default:
+                    return JsonDocument.ParseValue(ref reader).RootElement.Clone();
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, object objectToWrite, JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, objectToWrite, objectToWrite.GetType(), options);
+        }
+    }
+}

--- a/Appwrite/Converters/ValueClassConverter.cs
+++ b/Appwrite/Converters/ValueClassConverter.cs
@@ -1,38 +1,39 @@
 using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Appwrite.Enums;
-using Newtonsoft.Json;
 
 namespace Appwrite.Converters
 {
-    public class ValueClassConverter : JsonConverter {
-
-        public override bool CanConvert(System.Type objectType)
+    public class ValueClassConverter : JsonConverter<object>
+    {
+        public override bool CanConvert(Type objectType)
         {
             return typeof(IEnum).IsAssignableFrom(objectType);
         }
 
-        public override object ReadJson(JsonReader reader, System.Type objectType, object existingValue, JsonSerializer serializer)
+        public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var value = (string)reader.Value;
-            var constructor = objectType.GetConstructor(new[] { typeof(string) });
-            var obj = constructor.Invoke(new object[] { value });
+            var value = reader.GetString();
+            var constructor = typeToConvert.GetConstructor(new[] { typeof(string) });
+            var obj = constructor?.Invoke(new object[] { value! });
 
-            return Convert.ChangeType(obj, objectType);
+            return Convert.ChangeType(obj, typeToConvert)!;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
         {
             var type = value.GetType();
             var property = type.GetProperty(nameof(IEnum.Value));
-            var propertyValue = property.GetValue(value);
+            var propertyValue = property?.GetValue(value);
 
             if (propertyValue == null)
             {
-                writer.WriteNull();
+                writer.WriteNullValue();
                 return;
             }
 
-            writer.WriteValue(propertyValue);
+            writer.WriteStringValue(propertyValue.ToString());
         }
     }
 }

--- a/Appwrite/Enums/BuildRuntime.cs
+++ b/Appwrite/Enums/BuildRuntime.cs
@@ -48,6 +48,7 @@ namespace Appwrite.Enums
         public static BuildRuntime Dart31 => new BuildRuntime("dart-3.1");
         public static BuildRuntime Dart33 => new BuildRuntime("dart-3.3");
         public static BuildRuntime Dart35 => new BuildRuntime("dart-3.5");
+        public static BuildRuntime Dart38 => new BuildRuntime("dart-3.8");
         public static BuildRuntime Dotnet60 => new BuildRuntime("dotnet-6.0");
         public static BuildRuntime Dotnet70 => new BuildRuntime("dotnet-7.0");
         public static BuildRuntime Dotnet80 => new BuildRuntime("dotnet-8.0");
@@ -74,5 +75,6 @@ namespace Appwrite.Enums
         public static BuildRuntime Flutter324 => new BuildRuntime("flutter-3.24");
         public static BuildRuntime Flutter327 => new BuildRuntime("flutter-3.27");
         public static BuildRuntime Flutter329 => new BuildRuntime("flutter-3.29");
+        public static BuildRuntime Flutter332 => new BuildRuntime("flutter-3.32");
     }
 }

--- a/Appwrite/Enums/ImageFormat.cs
+++ b/Appwrite/Enums/ImageFormat.cs
@@ -17,5 +17,6 @@ namespace Appwrite.Enums
         public static ImageFormat Webp => new ImageFormat("webp");
         public static ImageFormat Heic => new ImageFormat("heic");
         public static ImageFormat Avif => new ImageFormat("avif");
+        public static ImageFormat Gif => new ImageFormat("gif");
     }
 }

--- a/Appwrite/Enums/Runtime.cs
+++ b/Appwrite/Enums/Runtime.cs
@@ -48,6 +48,7 @@ namespace Appwrite.Enums
         public static Runtime Dart31 => new Runtime("dart-3.1");
         public static Runtime Dart33 => new Runtime("dart-3.3");
         public static Runtime Dart35 => new Runtime("dart-3.5");
+        public static Runtime Dart38 => new Runtime("dart-3.8");
         public static Runtime Dotnet60 => new Runtime("dotnet-6.0");
         public static Runtime Dotnet70 => new Runtime("dotnet-7.0");
         public static Runtime Dotnet80 => new Runtime("dotnet-8.0");
@@ -74,5 +75,6 @@ namespace Appwrite.Enums
         public static Runtime Flutter324 => new Runtime("flutter-3.24");
         public static Runtime Flutter327 => new Runtime("flutter-3.27");
         public static Runtime Flutter329 => new Runtime("flutter-3.29");
+        public static Runtime Flutter332 => new Runtime("flutter-3.32");
     }
 }

--- a/Appwrite/Extensions/Extensions.cs
+++ b/Appwrite/Extensions/Extensions.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace Appwrite.Extensions
 {
@@ -9,7 +9,7 @@ namespace Appwrite.Extensions
     {
         public static string ToJson(this Dictionary<string, object?> dict)
         {
-            return JsonConvert.SerializeObject(dict, Client.SerializerSettings);
+            return JsonSerializer.Serialize(dict, Client.SerializerOptions);
         }
 
         public static string ToQueryString(this Dictionary<string, object?> parameters)

--- a/Appwrite/Models/AlgoArgon2.cs
+++ b/Appwrite/Models/AlgoArgon2.cs
@@ -2,24 +2,23 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AlgoArgon2
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("memoryCost")]
+        [JsonPropertyName("memoryCost")]
         public long MemoryCost { get; private set; }
 
-        [JsonProperty("timeCost")]
+        [JsonPropertyName("timeCost")]
         public long TimeCost { get; private set; }
 
-        [JsonProperty("threads")]
+        [JsonPropertyName("threads")]
         public long Threads { get; private set; }
 
         public AlgoArgon2(

--- a/Appwrite/Models/AlgoBcrypt.cs
+++ b/Appwrite/Models/AlgoBcrypt.cs
@@ -2,15 +2,14 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AlgoBcrypt
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
         public AlgoBcrypt(

--- a/Appwrite/Models/AlgoMd5.cs
+++ b/Appwrite/Models/AlgoMd5.cs
@@ -2,15 +2,14 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AlgoMd5
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
         public AlgoMd5(

--- a/Appwrite/Models/AlgoPhpass.cs
+++ b/Appwrite/Models/AlgoPhpass.cs
@@ -2,15 +2,14 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AlgoPhpass
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
         public AlgoPhpass(

--- a/Appwrite/Models/AlgoScrypt.cs
+++ b/Appwrite/Models/AlgoScrypt.cs
@@ -2,27 +2,26 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AlgoScrypt
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("costCpu")]
+        [JsonPropertyName("costCpu")]
         public long CostCpu { get; private set; }
 
-        [JsonProperty("costMemory")]
+        [JsonPropertyName("costMemory")]
         public long CostMemory { get; private set; }
 
-        [JsonProperty("costParallel")]
+        [JsonPropertyName("costParallel")]
         public long CostParallel { get; private set; }
 
-        [JsonProperty("length")]
+        [JsonPropertyName("length")]
         public long Length { get; private set; }
 
         public AlgoScrypt(

--- a/Appwrite/Models/AlgoScryptModified.cs
+++ b/Appwrite/Models/AlgoScryptModified.cs
@@ -2,24 +2,23 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AlgoScryptModified
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("salt")]
+        [JsonPropertyName("salt")]
         public string Salt { get; private set; }
 
-        [JsonProperty("saltSeparator")]
+        [JsonPropertyName("saltSeparator")]
         public string SaltSeparator { get; private set; }
 
-        [JsonProperty("signerKey")]
+        [JsonPropertyName("signerKey")]
         public string SignerKey { get; private set; }
 
         public AlgoScryptModified(

--- a/Appwrite/Models/AlgoSha.cs
+++ b/Appwrite/Models/AlgoSha.cs
@@ -2,15 +2,14 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AlgoSha
     {
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
         public AlgoSha(

--- a/Appwrite/Models/AttributeBoolean.cs
+++ b/Appwrite/Models/AttributeBoolean.cs
@@ -2,39 +2,38 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeBoolean
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public bool? Default { get; private set; }
 
         public AttributeBoolean(

--- a/Appwrite/Models/AttributeDatetime.cs
+++ b/Appwrite/Models/AttributeDatetime.cs
@@ -2,42 +2,41 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeDatetime
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("format")]
+        [JsonPropertyName("format")]
         public string Format { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public string? Default { get; private set; }
 
         public AttributeDatetime(

--- a/Appwrite/Models/AttributeEmail.cs
+++ b/Appwrite/Models/AttributeEmail.cs
@@ -2,42 +2,41 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeEmail
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("format")]
+        [JsonPropertyName("format")]
         public string Format { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public string? Default { get; private set; }
 
         public AttributeEmail(

--- a/Appwrite/Models/AttributeEnum.cs
+++ b/Appwrite/Models/AttributeEnum.cs
@@ -2,45 +2,44 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeEnum
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("elements")]
+        [JsonPropertyName("elements")]
         public List<string> Elements { get; private set; }
 
-        [JsonProperty("format")]
+        [JsonPropertyName("format")]
         public string Format { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public string? Default { get; private set; }
 
         public AttributeEnum(
@@ -78,7 +77,7 @@ namespace Appwrite.Models
             array: (bool?)map["array"],
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
-            elements: ((JArray)map["elements"]).ToObject<List<string>>(),
+            elements: map["elements"] is JsonElement jsonArrayProp9 ? jsonArrayProp9.Deserialize<List<string>>()! : (List<string>)map["elements"],
             format: map["format"].ToString(),
             xdefault: map.TryGetValue("default", out var xdefault) ? xdefault?.ToString() : null
         );

--- a/Appwrite/Models/AttributeFloat.cs
+++ b/Appwrite/Models/AttributeFloat.cs
@@ -2,45 +2,44 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeFloat
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("min")]
+        [JsonPropertyName("min")]
         public double? Min { get; private set; }
 
-        [JsonProperty("max")]
+        [JsonPropertyName("max")]
         public double? Max { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public double? Default { get; private set; }
 
         public AttributeFloat(

--- a/Appwrite/Models/AttributeInteger.cs
+++ b/Appwrite/Models/AttributeInteger.cs
@@ -2,45 +2,44 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeInteger
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("min")]
+        [JsonPropertyName("min")]
         public long? Min { get; private set; }
 
-        [JsonProperty("max")]
+        [JsonPropertyName("max")]
         public long? Max { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public long? Default { get; private set; }
 
         public AttributeInteger(

--- a/Appwrite/Models/AttributeIp.cs
+++ b/Appwrite/Models/AttributeIp.cs
@@ -2,42 +2,41 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeIp
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("format")]
+        [JsonPropertyName("format")]
         public string Format { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public string? Default { get; private set; }
 
         public AttributeIp(

--- a/Appwrite/Models/AttributeList.cs
+++ b/Appwrite/Models/AttributeList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("attributes")]
+        [JsonPropertyName("attributes")]
         public List<object> Attributes { get; private set; }
 
         public AttributeList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static AttributeList From(Dictionary<string, object> map) => new AttributeList(
             total: Convert.ToInt64(map["total"]),
-            attributes: ((JArray)map["attributes"]).ToObject<List<object>>()
+            attributes: map["attributes"] is JsonElement jsonArrayProp2 ? jsonArrayProp2.Deserialize<List<object>>()! : (List<object>)map["attributes"]
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/AttributeRelationship.cs
+++ b/Appwrite/Models/AttributeRelationship.cs
@@ -2,54 +2,53 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeRelationship
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("relatedCollection")]
+        [JsonPropertyName("relatedCollection")]
         public string RelatedCollection { get; private set; }
 
-        [JsonProperty("relationType")]
+        [JsonPropertyName("relationType")]
         public string RelationType { get; private set; }
 
-        [JsonProperty("twoWay")]
+        [JsonPropertyName("twoWay")]
         public bool TwoWay { get; private set; }
 
-        [JsonProperty("twoWayKey")]
+        [JsonPropertyName("twoWayKey")]
         public string TwoWayKey { get; private set; }
 
-        [JsonProperty("onDelete")]
+        [JsonPropertyName("onDelete")]
         public string OnDelete { get; private set; }
 
-        [JsonProperty("side")]
+        [JsonPropertyName("side")]
         public string Side { get; private set; }
 
         public AttributeRelationship(

--- a/Appwrite/Models/AttributeString.cs
+++ b/Appwrite/Models/AttributeString.cs
@@ -2,42 +2,41 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeString
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("size")]
+        [JsonPropertyName("size")]
         public long Size { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public string? Default { get; private set; }
 
         public AttributeString(

--- a/Appwrite/Models/AttributeUrl.cs
+++ b/Appwrite/Models/AttributeUrl.cs
@@ -2,42 +2,41 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class AttributeUrl
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("required")]
+        [JsonPropertyName("required")]
         public bool Required { get; private set; }
 
-        [JsonProperty("array")]
+        [JsonPropertyName("array")]
         public bool? Array { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("format")]
+        [JsonPropertyName("format")]
         public string Format { get; private set; }
 
-        [JsonProperty("default")]
+        [JsonPropertyName("default")]
         public string? Default { get; private set; }
 
         public AttributeUrl(

--- a/Appwrite/Models/Bucket.cs
+++ b/Appwrite/Models/Bucket.cs
@@ -2,48 +2,47 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Bucket
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("$permissions")]
+        [JsonPropertyName("$permissions")]
         public List<string> Permissions { get; private set; }
 
-        [JsonProperty("fileSecurity")]
+        [JsonPropertyName("fileSecurity")]
         public bool FileSecurity { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; private set; }
 
-        [JsonProperty("maximumFileSize")]
+        [JsonPropertyName("maximumFileSize")]
         public long MaximumFileSize { get; private set; }
 
-        [JsonProperty("allowedFileExtensions")]
+        [JsonPropertyName("allowedFileExtensions")]
         public List<string> AllowedFileExtensions { get; private set; }
 
-        [JsonProperty("compression")]
+        [JsonPropertyName("compression")]
         public string Compression { get; private set; }
 
-        [JsonProperty("encryption")]
+        [JsonPropertyName("encryption")]
         public bool Encryption { get; private set; }
 
-        [JsonProperty("antivirus")]
+        [JsonPropertyName("antivirus")]
         public bool Antivirus { get; private set; }
 
         public Bucket(
@@ -78,12 +77,12 @@ namespace Appwrite.Models
             id: map["$id"].ToString(),
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
-            permissions: ((JArray)map["$permissions"]).ToObject<List<string>>(),
+            permissions: map["$permissions"] is JsonElement jsonArrayProp4 ? jsonArrayProp4.Deserialize<List<string>>()! : (List<string>)map["$permissions"],
             fileSecurity: (bool)map["fileSecurity"],
             name: map["name"].ToString(),
             enabled: (bool)map["enabled"],
             maximumFileSize: Convert.ToInt64(map["maximumFileSize"]),
-            allowedFileExtensions: ((JArray)map["allowedFileExtensions"]).ToObject<List<string>>(),
+            allowedFileExtensions: map["allowedFileExtensions"] is JsonElement jsonArrayProp9 ? jsonArrayProp9.Deserialize<List<string>>()! : (List<string>)map["allowedFileExtensions"],
             compression: map["compression"].ToString(),
             encryption: (bool)map["encryption"],
             antivirus: (bool)map["antivirus"]

--- a/Appwrite/Models/BucketList.cs
+++ b/Appwrite/Models/BucketList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class BucketList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("buckets")]
+        [JsonPropertyName("buckets")]
         public List<Bucket> Buckets { get; private set; }
 
         public BucketList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static BucketList From(Dictionary<string, object> map) => new BucketList(
             total: Convert.ToInt64(map["total"]),
-            buckets: ((JArray)map["buckets"]).ToObject<List<Dictionary<string, object>>>().Select(it => Bucket.From(map: it)).ToList()
+            buckets: map["buckets"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Bucket.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["buckets"]).Select(it => Bucket.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Collection.cs
+++ b/Appwrite/Models/Collection.cs
@@ -2,42 +2,41 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Collection
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("$permissions")]
+        [JsonPropertyName("$permissions")]
         public List<string> Permissions { get; private set; }
 
-        [JsonProperty("databaseId")]
+        [JsonPropertyName("databaseId")]
         public string DatabaseId { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; private set; }
 
-        [JsonProperty("documentSecurity")]
+        [JsonPropertyName("documentSecurity")]
         public bool DocumentSecurity { get; private set; }
 
-        [JsonProperty("attributes")]
+        [JsonPropertyName("attributes")]
         public List<object> Attributes { get; private set; }
 
-        [JsonProperty("indexes")]
+        [JsonPropertyName("indexes")]
         public List<Index> Indexes { get; private set; }
 
         public Collection(
@@ -68,13 +67,13 @@ namespace Appwrite.Models
             id: map["$id"].ToString(),
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
-            permissions: ((JArray)map["$permissions"]).ToObject<List<string>>(),
+            permissions: map["$permissions"] is JsonElement jsonArrayProp4 ? jsonArrayProp4.Deserialize<List<string>>()! : (List<string>)map["$permissions"],
             databaseId: map["databaseId"].ToString(),
             name: map["name"].ToString(),
             enabled: (bool)map["enabled"],
             documentSecurity: (bool)map["documentSecurity"],
-            attributes: ((JArray)map["attributes"]).ToObject<List<object>>(),
-            indexes: ((JArray)map["indexes"]).ToObject<List<Dictionary<string, object>>>().Select(it => Index.From(map: it)).ToList()
+            attributes: map["attributes"] is JsonElement jsonArrayProp9 ? jsonArrayProp9.Deserialize<List<object>>()! : (List<object>)map["attributes"],
+            indexes: map["indexes"] is JsonElement jsonArray10 ? jsonArray10.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Index.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["indexes"]).Select(it => Index.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/CollectionList.cs
+++ b/Appwrite/Models/CollectionList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class CollectionList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("collections")]
+        [JsonPropertyName("collections")]
         public List<Collection> Collections { get; private set; }
 
         public CollectionList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static CollectionList From(Dictionary<string, object> map) => new CollectionList(
             total: Convert.ToInt64(map["total"]),
-            collections: ((JArray)map["collections"]).ToObject<List<Dictionary<string, object>>>().Select(it => Collection.From(map: it)).ToList()
+            collections: map["collections"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Collection.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["collections"]).Select(it => Collection.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Continent.cs
+++ b/Appwrite/Models/Continent.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Continent
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; private set; }
 
         public Continent(

--- a/Appwrite/Models/ContinentList.cs
+++ b/Appwrite/Models/ContinentList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class ContinentList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("continents")]
+        [JsonPropertyName("continents")]
         public List<Continent> Continents { get; private set; }
 
         public ContinentList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static ContinentList From(Dictionary<string, object> map) => new ContinentList(
             total: Convert.ToInt64(map["total"]),
-            continents: ((JArray)map["continents"]).ToObject<List<Dictionary<string, object>>>().Select(it => Continent.From(map: it)).ToList()
+            continents: map["continents"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Continent.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["continents"]).Select(it => Continent.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Country.cs
+++ b/Appwrite/Models/Country.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Country
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; private set; }
 
         public Country(

--- a/Appwrite/Models/CountryList.cs
+++ b/Appwrite/Models/CountryList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class CountryList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("countries")]
+        [JsonPropertyName("countries")]
         public List<Country> Countries { get; private set; }
 
         public CountryList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static CountryList From(Dictionary<string, object> map) => new CountryList(
             total: Convert.ToInt64(map["total"]),
-            countries: ((JArray)map["countries"]).ToObject<List<Dictionary<string, object>>>().Select(it => Country.From(map: it)).ToList()
+            countries: map["countries"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Country.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["countries"]).Select(it => Country.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Currency.cs
+++ b/Appwrite/Models/Currency.cs
@@ -2,33 +2,32 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Currency
     {
-        [JsonProperty("symbol")]
+        [JsonPropertyName("symbol")]
         public string Symbol { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("symbolNative")]
+        [JsonPropertyName("symbolNative")]
         public string SymbolNative { get; private set; }
 
-        [JsonProperty("decimalDigits")]
+        [JsonPropertyName("decimalDigits")]
         public long DecimalDigits { get; private set; }
 
-        [JsonProperty("rounding")]
+        [JsonPropertyName("rounding")]
         public double Rounding { get; private set; }
 
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; private set; }
 
-        [JsonProperty("namePlural")]
+        [JsonPropertyName("namePlural")]
         public string NamePlural { get; private set; }
 
         public Currency(

--- a/Appwrite/Models/CurrencyList.cs
+++ b/Appwrite/Models/CurrencyList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class CurrencyList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("currencies")]
+        [JsonPropertyName("currencies")]
         public List<Currency> Currencies { get; private set; }
 
         public CurrencyList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static CurrencyList From(Dictionary<string, object> map) => new CurrencyList(
             total: Convert.ToInt64(map["total"]),
-            currencies: ((JArray)map["currencies"]).ToObject<List<Dictionary<string, object>>>().Select(it => Currency.From(map: it)).ToList()
+            currencies: map["currencies"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Currency.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["currencies"]).Select(it => Currency.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Database.cs
+++ b/Appwrite/Models/Database.cs
@@ -2,27 +2,26 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Database
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; private set; }
 
         public Database(

--- a/Appwrite/Models/DatabaseList.cs
+++ b/Appwrite/Models/DatabaseList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class DatabaseList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("databases")]
+        [JsonPropertyName("databases")]
         public List<Database> Databases { get; private set; }
 
         public DatabaseList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static DatabaseList From(Dictionary<string, object> map) => new DatabaseList(
             total: Convert.ToInt64(map["total"]),
-            databases: ((JArray)map["databases"]).ToObject<List<Dictionary<string, object>>>().Select(it => Database.From(map: it)).ToList()
+            databases: map["databases"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Database.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["databases"]).Select(it => Database.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Deployment.cs
+++ b/Appwrite/Models/Deployment.cs
@@ -2,93 +2,92 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Deployment
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("resourceId")]
+        [JsonPropertyName("resourceId")]
         public string ResourceId { get; private set; }
 
-        [JsonProperty("resourceType")]
+        [JsonPropertyName("resourceType")]
         public string ResourceType { get; private set; }
 
-        [JsonProperty("entrypoint")]
+        [JsonPropertyName("entrypoint")]
         public string Entrypoint { get; private set; }
 
-        [JsonProperty("sourceSize")]
+        [JsonPropertyName("sourceSize")]
         public long SourceSize { get; private set; }
 
-        [JsonProperty("buildSize")]
+        [JsonPropertyName("buildSize")]
         public long BuildSize { get; private set; }
 
-        [JsonProperty("totalSize")]
+        [JsonPropertyName("totalSize")]
         public long TotalSize { get; private set; }
 
-        [JsonProperty("buildId")]
+        [JsonPropertyName("buildId")]
         public string BuildId { get; private set; }
 
-        [JsonProperty("activate")]
+        [JsonPropertyName("activate")]
         public bool Activate { get; private set; }
 
-        [JsonProperty("screenshotLight")]
+        [JsonPropertyName("screenshotLight")]
         public string ScreenshotLight { get; private set; }
 
-        [JsonProperty("screenshotDark")]
+        [JsonPropertyName("screenshotDark")]
         public string ScreenshotDark { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("buildLogs")]
+        [JsonPropertyName("buildLogs")]
         public string BuildLogs { get; private set; }
 
-        [JsonProperty("buildDuration")]
+        [JsonPropertyName("buildDuration")]
         public long BuildDuration { get; private set; }
 
-        [JsonProperty("providerRepositoryName")]
+        [JsonPropertyName("providerRepositoryName")]
         public string ProviderRepositoryName { get; private set; }
 
-        [JsonProperty("providerRepositoryOwner")]
+        [JsonPropertyName("providerRepositoryOwner")]
         public string ProviderRepositoryOwner { get; private set; }
 
-        [JsonProperty("providerRepositoryUrl")]
+        [JsonPropertyName("providerRepositoryUrl")]
         public string ProviderRepositoryUrl { get; private set; }
 
-        [JsonProperty("providerBranch")]
+        [JsonPropertyName("providerBranch")]
         public string ProviderBranch { get; private set; }
 
-        [JsonProperty("providerCommitHash")]
+        [JsonPropertyName("providerCommitHash")]
         public string ProviderCommitHash { get; private set; }
 
-        [JsonProperty("providerCommitAuthorUrl")]
+        [JsonPropertyName("providerCommitAuthorUrl")]
         public string ProviderCommitAuthorUrl { get; private set; }
 
-        [JsonProperty("providerCommitAuthor")]
+        [JsonPropertyName("providerCommitAuthor")]
         public string ProviderCommitAuthor { get; private set; }
 
-        [JsonProperty("providerCommitMessage")]
+        [JsonPropertyName("providerCommitMessage")]
         public string ProviderCommitMessage { get; private set; }
 
-        [JsonProperty("providerCommitUrl")]
+        [JsonPropertyName("providerCommitUrl")]
         public string ProviderCommitUrl { get; private set; }
 
-        [JsonProperty("providerBranchUrl")]
+        [JsonPropertyName("providerBranchUrl")]
         public string ProviderBranchUrl { get; private set; }
 
         public Deployment(

--- a/Appwrite/Models/DeploymentList.cs
+++ b/Appwrite/Models/DeploymentList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class DeploymentList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("deployments")]
+        [JsonPropertyName("deployments")]
         public List<Deployment> Deployments { get; private set; }
 
         public DeploymentList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static DeploymentList From(Dictionary<string, object> map) => new DeploymentList(
             total: Convert.ToInt64(map["total"]),
-            deployments: ((JArray)map["deployments"]).ToObject<List<Dictionary<string, object>>>().Select(it => Deployment.From(map: it)).ToList()
+            deployments: map["deployments"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Deployment.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["deployments"]).Select(it => Deployment.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Document.cs
+++ b/Appwrite/Models/Document.cs
@@ -2,30 +2,29 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Document
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$collectionId")]
+        [JsonPropertyName("$collectionId")]
         public string CollectionId { get; private set; }
 
-        [JsonProperty("$databaseId")]
+        [JsonPropertyName("$databaseId")]
         public string DatabaseId { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("$permissions")]
+        [JsonPropertyName("$permissions")]
         public List<string> Permissions { get; private set; }
 
         public Dictionary<string, object> Data { get; private set; }
@@ -54,7 +53,7 @@ namespace Appwrite.Models
             databaseId: map["$databaseId"].ToString(),
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
-            permissions: ((JArray)map["$permissions"]).ToObject<List<string>>(),
+            permissions: map["$permissions"] is JsonElement jsonArrayProp6 ? jsonArrayProp6.Deserialize<List<string>>()! : (List<string>)map["$permissions"],
             data: map
         );
 

--- a/Appwrite/Models/DocumentList.cs
+++ b/Appwrite/Models/DocumentList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class DocumentList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("documents")]
+        [JsonPropertyName("documents")]
         public List<Document> Documents { get; private set; }
 
         public DocumentList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static DocumentList From(Dictionary<string, object> map) => new DocumentList(
             total: Convert.ToInt64(map["total"]),
-            documents: ((JArray)map["documents"]).ToObject<List<Dictionary<string, object>>>().Select(it => Document.From(map: it)).ToList()
+            documents: map["documents"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Document.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["documents"]).Select(it => Document.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Execution.cs
+++ b/Appwrite/Models/Execution.cs
@@ -2,63 +2,62 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Execution
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("$permissions")]
+        [JsonPropertyName("$permissions")]
         public List<string> Permissions { get; private set; }
 
-        [JsonProperty("functionId")]
+        [JsonPropertyName("functionId")]
         public string FunctionId { get; private set; }
 
-        [JsonProperty("trigger")]
+        [JsonPropertyName("trigger")]
         public string Trigger { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("requestMethod")]
+        [JsonPropertyName("requestMethod")]
         public string RequestMethod { get; private set; }
 
-        [JsonProperty("requestPath")]
+        [JsonPropertyName("requestPath")]
         public string RequestPath { get; private set; }
 
-        [JsonProperty("requestHeaders")]
+        [JsonPropertyName("requestHeaders")]
         public List<Headers> RequestHeaders { get; private set; }
 
-        [JsonProperty("responseStatusCode")]
+        [JsonPropertyName("responseStatusCode")]
         public long ResponseStatusCode { get; private set; }
 
-        [JsonProperty("responseBody")]
+        [JsonPropertyName("responseBody")]
         public string ResponseBody { get; private set; }
 
-        [JsonProperty("responseHeaders")]
+        [JsonPropertyName("responseHeaders")]
         public List<Headers> ResponseHeaders { get; private set; }
 
-        [JsonProperty("logs")]
+        [JsonPropertyName("logs")]
         public string Logs { get; private set; }
 
-        [JsonProperty("errors")]
+        [JsonPropertyName("errors")]
         public string Errors { get; private set; }
 
-        [JsonProperty("duration")]
+        [JsonPropertyName("duration")]
         public double Duration { get; private set; }
 
-        [JsonProperty("scheduledAt")]
+        [JsonPropertyName("scheduledAt")]
         public string? ScheduledAt { get; private set; }
 
         public Execution(
@@ -103,16 +102,16 @@ namespace Appwrite.Models
             id: map["$id"].ToString(),
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
-            permissions: ((JArray)map["$permissions"]).ToObject<List<string>>(),
+            permissions: map["$permissions"] is JsonElement jsonArrayProp4 ? jsonArrayProp4.Deserialize<List<string>>()! : (List<string>)map["$permissions"],
             functionId: map["functionId"].ToString(),
             trigger: map["trigger"].ToString(),
             status: map["status"].ToString(),
             requestMethod: map["requestMethod"].ToString(),
             requestPath: map["requestPath"].ToString(),
-            requestHeaders: ((JArray)map["requestHeaders"]).ToObject<List<Dictionary<string, object>>>().Select(it => Headers.From(map: it)).ToList(),
+            requestHeaders: map["requestHeaders"] is JsonElement jsonArray10 ? jsonArray10.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Headers.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["requestHeaders"]).Select(it => Headers.From(map: it)).ToList(),
             responseStatusCode: Convert.ToInt64(map["responseStatusCode"]),
             responseBody: map["responseBody"].ToString(),
-            responseHeaders: ((JArray)map["responseHeaders"]).ToObject<List<Dictionary<string, object>>>().Select(it => Headers.From(map: it)).ToList(),
+            responseHeaders: map["responseHeaders"] is JsonElement jsonArray13 ? jsonArray13.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Headers.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["responseHeaders"]).Select(it => Headers.From(map: it)).ToList(),
             logs: map["logs"].ToString(),
             errors: map["errors"].ToString(),
             duration: Convert.ToDouble(map["duration"]),

--- a/Appwrite/Models/ExecutionList.cs
+++ b/Appwrite/Models/ExecutionList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class ExecutionList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("executions")]
+        [JsonPropertyName("executions")]
         public List<Execution> Executions { get; private set; }
 
         public ExecutionList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static ExecutionList From(Dictionary<string, object> map) => new ExecutionList(
             total: Convert.ToInt64(map["total"]),
-            executions: ((JArray)map["executions"]).ToObject<List<Dictionary<string, object>>>().Select(it => Execution.From(map: it)).ToList()
+            executions: map["executions"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Execution.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["executions"]).Select(it => Execution.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/File.cs
+++ b/Appwrite/Models/File.cs
@@ -2,45 +2,44 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class File
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("bucketId")]
+        [JsonPropertyName("bucketId")]
         public string BucketId { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("$permissions")]
+        [JsonPropertyName("$permissions")]
         public List<string> Permissions { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("signature")]
+        [JsonPropertyName("signature")]
         public string Signature { get; private set; }
 
-        [JsonProperty("mimeType")]
+        [JsonPropertyName("mimeType")]
         public string MimeType { get; private set; }
 
-        [JsonProperty("sizeOriginal")]
+        [JsonPropertyName("sizeOriginal")]
         public long SizeOriginal { get; private set; }
 
-        [JsonProperty("chunksTotal")]
+        [JsonPropertyName("chunksTotal")]
         public long ChunksTotal { get; private set; }
 
-        [JsonProperty("chunksUploaded")]
+        [JsonPropertyName("chunksUploaded")]
         public long ChunksUploaded { get; private set; }
 
         public File(
@@ -74,7 +73,7 @@ namespace Appwrite.Models
             bucketId: map["bucketId"].ToString(),
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
-            permissions: ((JArray)map["$permissions"]).ToObject<List<string>>(),
+            permissions: map["$permissions"] is JsonElement jsonArrayProp5 ? jsonArrayProp5.Deserialize<List<string>>()! : (List<string>)map["$permissions"],
             name: map["name"].ToString(),
             signature: map["signature"].ToString(),
             mimeType: map["mimeType"].ToString(),

--- a/Appwrite/Models/FileList.cs
+++ b/Appwrite/Models/FileList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class FileList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("files")]
+        [JsonPropertyName("files")]
         public List<File> Files { get; private set; }
 
         public FileList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static FileList From(Dictionary<string, object> map) => new FileList(
             total: Convert.ToInt64(map["total"]),
-            files: ((JArray)map["files"]).ToObject<List<Dictionary<string, object>>>().Select(it => File.From(map: it)).ToList()
+            files: map["files"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => File.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["files"]).Select(it => File.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Framework.cs
+++ b/Appwrite/Models/Framework.cs
@@ -2,27 +2,26 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Framework
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("buildRuntime")]
+        [JsonPropertyName("buildRuntime")]
         public string BuildRuntime { get; private set; }
 
-        [JsonProperty("runtimes")]
+        [JsonPropertyName("runtimes")]
         public List<string> Runtimes { get; private set; }
 
-        [JsonProperty("adapters")]
+        [JsonPropertyName("adapters")]
         public List<FrameworkAdapter> Adapters { get; private set; }
 
         public Framework(
@@ -43,8 +42,8 @@ namespace Appwrite.Models
             key: map["key"].ToString(),
             name: map["name"].ToString(),
             buildRuntime: map["buildRuntime"].ToString(),
-            runtimes: ((JArray)map["runtimes"]).ToObject<List<string>>(),
-            adapters: ((JArray)map["adapters"]).ToObject<List<Dictionary<string, object>>>().Select(it => FrameworkAdapter.From(map: it)).ToList()
+            runtimes: map["runtimes"] is JsonElement jsonArrayProp4 ? jsonArrayProp4.Deserialize<List<string>>()! : (List<string>)map["runtimes"],
+            adapters: map["adapters"] is JsonElement jsonArray5 ? jsonArray5.Deserialize<List<Dictionary<string, object>>>()!.Select(it => FrameworkAdapter.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["adapters"]).Select(it => FrameworkAdapter.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/FrameworkAdapter.cs
+++ b/Appwrite/Models/FrameworkAdapter.cs
@@ -2,27 +2,26 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class FrameworkAdapter
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("installCommand")]
+        [JsonPropertyName("installCommand")]
         public string InstallCommand { get; private set; }
 
-        [JsonProperty("buildCommand")]
+        [JsonPropertyName("buildCommand")]
         public string BuildCommand { get; private set; }
 
-        [JsonProperty("outputDirectory")]
+        [JsonPropertyName("outputDirectory")]
         public string OutputDirectory { get; private set; }
 
-        [JsonProperty("fallbackFile")]
+        [JsonPropertyName("fallbackFile")]
         public string FallbackFile { get; private set; }
 
         public FrameworkAdapter(

--- a/Appwrite/Models/FrameworkList.cs
+++ b/Appwrite/Models/FrameworkList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class FrameworkList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("frameworks")]
+        [JsonPropertyName("frameworks")]
         public List<Framework> Frameworks { get; private set; }
 
         public FrameworkList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static FrameworkList From(Dictionary<string, object> map) => new FrameworkList(
             total: Convert.ToInt64(map["total"]),
-            frameworks: ((JArray)map["frameworks"]).ToObject<List<Dictionary<string, object>>>().Select(it => Framework.From(map: it)).ToList()
+            frameworks: map["frameworks"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Framework.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["frameworks"]).Select(it => Framework.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Function.cs
+++ b/Appwrite/Models/Function.cs
@@ -2,96 +2,95 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Function
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("execute")]
+        [JsonPropertyName("execute")]
         public List<string> Execute { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; private set; }
 
-        [JsonProperty("live")]
+        [JsonPropertyName("live")]
         public bool Live { get; private set; }
 
-        [JsonProperty("logging")]
+        [JsonPropertyName("logging")]
         public bool Logging { get; private set; }
 
-        [JsonProperty("runtime")]
+        [JsonPropertyName("runtime")]
         public string Runtime { get; private set; }
 
-        [JsonProperty("deploymentId")]
+        [JsonPropertyName("deploymentId")]
         public string DeploymentId { get; private set; }
 
-        [JsonProperty("deploymentCreatedAt")]
+        [JsonPropertyName("deploymentCreatedAt")]
         public string DeploymentCreatedAt { get; private set; }
 
-        [JsonProperty("latestDeploymentId")]
+        [JsonPropertyName("latestDeploymentId")]
         public string LatestDeploymentId { get; private set; }
 
-        [JsonProperty("latestDeploymentCreatedAt")]
+        [JsonPropertyName("latestDeploymentCreatedAt")]
         public string LatestDeploymentCreatedAt { get; private set; }
 
-        [JsonProperty("latestDeploymentStatus")]
+        [JsonPropertyName("latestDeploymentStatus")]
         public string LatestDeploymentStatus { get; private set; }
 
-        [JsonProperty("scopes")]
+        [JsonPropertyName("scopes")]
         public List<string> Scopes { get; private set; }
 
-        [JsonProperty("vars")]
+        [JsonPropertyName("vars")]
         public List<Variable> Vars { get; private set; }
 
-        [JsonProperty("events")]
+        [JsonPropertyName("events")]
         public List<string> Events { get; private set; }
 
-        [JsonProperty("schedule")]
+        [JsonPropertyName("schedule")]
         public string Schedule { get; private set; }
 
-        [JsonProperty("timeout")]
+        [JsonPropertyName("timeout")]
         public long Timeout { get; private set; }
 
-        [JsonProperty("entrypoint")]
+        [JsonPropertyName("entrypoint")]
         public string Entrypoint { get; private set; }
 
-        [JsonProperty("commands")]
+        [JsonPropertyName("commands")]
         public string Commands { get; private set; }
 
-        [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public string Version { get; private set; }
 
-        [JsonProperty("installationId")]
+        [JsonPropertyName("installationId")]
         public string InstallationId { get; private set; }
 
-        [JsonProperty("providerRepositoryId")]
+        [JsonPropertyName("providerRepositoryId")]
         public string ProviderRepositoryId { get; private set; }
 
-        [JsonProperty("providerBranch")]
+        [JsonPropertyName("providerBranch")]
         public string ProviderBranch { get; private set; }
 
-        [JsonProperty("providerRootDirectory")]
+        [JsonPropertyName("providerRootDirectory")]
         public string ProviderRootDirectory { get; private set; }
 
-        [JsonProperty("providerSilentMode")]
+        [JsonPropertyName("providerSilentMode")]
         public bool ProviderSilentMode { get; private set; }
 
-        [JsonProperty("specification")]
+        [JsonPropertyName("specification")]
         public string Specification { get; private set; }
 
         public Function(
@@ -158,7 +157,7 @@ namespace Appwrite.Models
             id: map["$id"].ToString(),
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
-            execute: ((JArray)map["execute"]).ToObject<List<string>>(),
+            execute: map["execute"] is JsonElement jsonArrayProp4 ? jsonArrayProp4.Deserialize<List<string>>()! : (List<string>)map["execute"],
             name: map["name"].ToString(),
             enabled: (bool)map["enabled"],
             live: (bool)map["live"],
@@ -169,9 +168,9 @@ namespace Appwrite.Models
             latestDeploymentId: map["latestDeploymentId"].ToString(),
             latestDeploymentCreatedAt: map["latestDeploymentCreatedAt"].ToString(),
             latestDeploymentStatus: map["latestDeploymentStatus"].ToString(),
-            scopes: ((JArray)map["scopes"]).ToObject<List<string>>(),
-            vars: ((JArray)map["vars"]).ToObject<List<Dictionary<string, object>>>().Select(it => Variable.From(map: it)).ToList(),
-            events: ((JArray)map["events"]).ToObject<List<string>>(),
+            scopes: map["scopes"] is JsonElement jsonArrayProp15 ? jsonArrayProp15.Deserialize<List<string>>()! : (List<string>)map["scopes"],
+            vars: map["vars"] is JsonElement jsonArray16 ? jsonArray16.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Variable.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["vars"]).Select(it => Variable.From(map: it)).ToList(),
+            events: map["events"] is JsonElement jsonArrayProp17 ? jsonArrayProp17.Deserialize<List<string>>()! : (List<string>)map["events"],
             schedule: map["schedule"].ToString(),
             timeout: Convert.ToInt64(map["timeout"]),
             entrypoint: map["entrypoint"].ToString(),

--- a/Appwrite/Models/FunctionList.cs
+++ b/Appwrite/Models/FunctionList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class FunctionList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("functions")]
+        [JsonPropertyName("functions")]
         public List<Function> Functions { get; private set; }
 
         public FunctionList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static FunctionList From(Dictionary<string, object> map) => new FunctionList(
             total: Convert.ToInt64(map["total"]),
-            functions: ((JArray)map["functions"]).ToObject<List<Dictionary<string, object>>>().Select(it => Function.From(map: it)).ToList()
+            functions: map["functions"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Function.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["functions"]).Select(it => Function.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Headers.cs
+++ b/Appwrite/Models/Headers.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Headers
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public string Value { get; private set; }
 
         public Headers(

--- a/Appwrite/Models/HealthAntivirus.cs
+++ b/Appwrite/Models/HealthAntivirus.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class HealthAntivirus
     {
-        [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public string Version { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
         public HealthAntivirus(

--- a/Appwrite/Models/HealthCertificate.cs
+++ b/Appwrite/Models/HealthCertificate.cs
@@ -2,30 +2,29 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class HealthCertificate
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("subjectSN")]
+        [JsonPropertyName("subjectSN")]
         public string SubjectSN { get; private set; }
 
-        [JsonProperty("issuerOrganisation")]
+        [JsonPropertyName("issuerOrganisation")]
         public string IssuerOrganisation { get; private set; }
 
-        [JsonProperty("validFrom")]
+        [JsonPropertyName("validFrom")]
         public string ValidFrom { get; private set; }
 
-        [JsonProperty("validTo")]
+        [JsonPropertyName("validTo")]
         public string ValidTo { get; private set; }
 
-        [JsonProperty("signatureTypeSN")]
+        [JsonPropertyName("signatureTypeSN")]
         public string SignatureTypeSN { get; private set; }
 
         public HealthCertificate(

--- a/Appwrite/Models/HealthQueue.cs
+++ b/Appwrite/Models/HealthQueue.cs
@@ -2,15 +2,14 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class HealthQueue
     {
-        [JsonProperty("size")]
+        [JsonPropertyName("size")]
         public long Size { get; private set; }
 
         public HealthQueue(

--- a/Appwrite/Models/HealthStatus.cs
+++ b/Appwrite/Models/HealthStatus.cs
@@ -2,21 +2,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class HealthStatus
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("ping")]
+        [JsonPropertyName("ping")]
         public long Ping { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
         public HealthStatus(

--- a/Appwrite/Models/HealthTime.cs
+++ b/Appwrite/Models/HealthTime.cs
@@ -2,21 +2,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class HealthTime
     {
-        [JsonProperty("remoteTime")]
+        [JsonPropertyName("remoteTime")]
         public long RemoteTime { get; private set; }
 
-        [JsonProperty("localTime")]
+        [JsonPropertyName("localTime")]
         public long LocalTime { get; private set; }
 
-        [JsonProperty("diff")]
+        [JsonPropertyName("diff")]
         public long Diff { get; private set; }
 
         public HealthTime(

--- a/Appwrite/Models/Identity.cs
+++ b/Appwrite/Models/Identity.cs
@@ -2,42 +2,41 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Identity
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("userId")]
+        [JsonPropertyName("userId")]
         public string UserId { get; private set; }
 
-        [JsonProperty("provider")]
+        [JsonPropertyName("provider")]
         public string Provider { get; private set; }
 
-        [JsonProperty("providerUid")]
+        [JsonPropertyName("providerUid")]
         public string ProviderUid { get; private set; }
 
-        [JsonProperty("providerEmail")]
+        [JsonPropertyName("providerEmail")]
         public string ProviderEmail { get; private set; }
 
-        [JsonProperty("providerAccessToken")]
+        [JsonPropertyName("providerAccessToken")]
         public string ProviderAccessToken { get; private set; }
 
-        [JsonProperty("providerAccessTokenExpiry")]
+        [JsonPropertyName("providerAccessTokenExpiry")]
         public string ProviderAccessTokenExpiry { get; private set; }
 
-        [JsonProperty("providerRefreshToken")]
+        [JsonPropertyName("providerRefreshToken")]
         public string ProviderRefreshToken { get; private set; }
 
         public Identity(

--- a/Appwrite/Models/IdentityList.cs
+++ b/Appwrite/Models/IdentityList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class IdentityList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("identities")]
+        [JsonPropertyName("identities")]
         public List<Identity> Identities { get; private set; }
 
         public IdentityList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static IdentityList From(Dictionary<string, object> map) => new IdentityList(
             total: Convert.ToInt64(map["total"]),
-            identities: ((JArray)map["identities"]).ToObject<List<Dictionary<string, object>>>().Select(it => Identity.From(map: it)).ToList()
+            identities: map["identities"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Identity.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["identities"]).Select(it => Identity.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Index.cs
+++ b/Appwrite/Models/Index.cs
@@ -2,39 +2,38 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Index
     {
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
-        [JsonProperty("error")]
+        [JsonPropertyName("error")]
         public string Error { get; private set; }
 
-        [JsonProperty("attributes")]
+        [JsonPropertyName("attributes")]
         public List<string> Attributes { get; private set; }
 
-        [JsonProperty("lengths")]
+        [JsonPropertyName("lengths")]
         public List<long> Lengths { get; private set; }
 
-        [JsonProperty("orders")]
+        [JsonPropertyName("orders")]
         public List<string>? Orders { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
         public Index(
@@ -64,9 +63,9 @@ namespace Appwrite.Models
             type: map["type"].ToString(),
             status: map["status"].ToString(),
             error: map["error"].ToString(),
-            attributes: ((JArray)map["attributes"]).ToObject<List<string>>(),
-            lengths: ((JArray)map["lengths"]).ToObject<List<long>>(),
-            orders: ((JArray)map["orders"]).ToObject<List<string>>(),
+            attributes: map["attributes"] is JsonElement jsonArrayProp5 ? jsonArrayProp5.Deserialize<List<string>>()! : (List<string>)map["attributes"],
+            lengths: map["lengths"] is JsonElement jsonArrayProp6 ? jsonArrayProp6.Deserialize<List<long>>()! : (List<long>)map["lengths"],
+            orders: map["orders"] is JsonElement jsonArrayProp7 ? jsonArrayProp7.Deserialize<List<string>>()! : (List<string>)map["orders"],
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString()
         );

--- a/Appwrite/Models/IndexList.cs
+++ b/Appwrite/Models/IndexList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class IndexList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("indexes")]
+        [JsonPropertyName("indexes")]
         public List<Index> Indexes { get; private set; }
 
         public IndexList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static IndexList From(Dictionary<string, object> map) => new IndexList(
             total: Convert.ToInt64(map["total"]),
-            indexes: ((JArray)map["indexes"]).ToObject<List<Dictionary<string, object>>>().Select(it => Index.From(map: it)).ToList()
+            indexes: map["indexes"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Index.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["indexes"]).Select(it => Index.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/InputFile.cs
+++ b/Appwrite/Models/InputFile.cs
@@ -5,11 +5,11 @@ namespace Appwrite.Models
 {
     public class InputFile
     {
-        public string Path { get; set; }
-        public string Filename { get; set; }
-        public string MimeType { get; set; }
-        public string SourceType { get; set; }
-        public object Data { get; set; }
+        public string Path { get; set; } = string.Empty;
+        public string Filename { get; set; } = string.Empty;
+        public string MimeType { get; set; } = string.Empty;
+        public string SourceType { get; set; } = string.Empty;
+        public object Data { get; set; } = new object();
 
         public static InputFile FromPath(string path) => new InputFile
         {

--- a/Appwrite/Models/JWT.cs
+++ b/Appwrite/Models/JWT.cs
@@ -2,15 +2,14 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class JWT
     {
-        [JsonProperty("jwt")]
+        [JsonPropertyName("jwt")]
         public string Jwt { get; private set; }
 
         public JWT(

--- a/Appwrite/Models/Language.cs
+++ b/Appwrite/Models/Language.cs
@@ -2,21 +2,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Language
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; private set; }
 
-        [JsonProperty("nativeName")]
+        [JsonPropertyName("nativeName")]
         public string NativeName { get; private set; }
 
         public Language(

--- a/Appwrite/Models/LanguageList.cs
+++ b/Appwrite/Models/LanguageList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class LanguageList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("languages")]
+        [JsonPropertyName("languages")]
         public List<Language> Languages { get; private set; }
 
         public LanguageList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static LanguageList From(Dictionary<string, object> map) => new LanguageList(
             total: Convert.ToInt64(map["total"]),
-            languages: ((JArray)map["languages"]).ToObject<List<Dictionary<string, object>>>().Select(it => Language.From(map: it)).ToList()
+            languages: map["languages"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Language.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["languages"]).Select(it => Language.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Locale.cs
+++ b/Appwrite/Models/Locale.cs
@@ -2,33 +2,32 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Locale
     {
-        [JsonProperty("ip")]
+        [JsonPropertyName("ip")]
         public string Ip { get; private set; }
 
-        [JsonProperty("countryCode")]
+        [JsonPropertyName("countryCode")]
         public string CountryCode { get; private set; }
 
-        [JsonProperty("country")]
+        [JsonPropertyName("country")]
         public string Country { get; private set; }
 
-        [JsonProperty("continentCode")]
+        [JsonPropertyName("continentCode")]
         public string ContinentCode { get; private set; }
 
-        [JsonProperty("continent")]
+        [JsonPropertyName("continent")]
         public string Continent { get; private set; }
 
-        [JsonProperty("eu")]
+        [JsonPropertyName("eu")]
         public bool Eu { get; private set; }
 
-        [JsonProperty("currency")]
+        [JsonPropertyName("currency")]
         public string Currency { get; private set; }
 
         public Locale(

--- a/Appwrite/Models/LocaleCode.cs
+++ b/Appwrite/Models/LocaleCode.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class LocaleCode
     {
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
         public LocaleCode(

--- a/Appwrite/Models/LocaleCodeList.cs
+++ b/Appwrite/Models/LocaleCodeList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class LocaleCodeList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("localeCodes")]
+        [JsonPropertyName("localeCodes")]
         public List<LocaleCode> LocaleCodes { get; private set; }
 
         public LocaleCodeList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static LocaleCodeList From(Dictionary<string, object> map) => new LocaleCodeList(
             total: Convert.ToInt64(map["total"]),
-            localeCodes: ((JArray)map["localeCodes"]).ToObject<List<Dictionary<string, object>>>().Select(it => LocaleCode.From(map: it)).ToList()
+            localeCodes: map["localeCodes"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => LocaleCode.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["localeCodes"]).Select(it => LocaleCode.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Log.cs
+++ b/Appwrite/Models/Log.cs
@@ -2,75 +2,74 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Log
     {
-        [JsonProperty("event")]
+        [JsonPropertyName("event")]
         public string Event { get; private set; }
 
-        [JsonProperty("userId")]
+        [JsonPropertyName("userId")]
         public string UserId { get; private set; }
 
-        [JsonProperty("userEmail")]
+        [JsonPropertyName("userEmail")]
         public string UserEmail { get; private set; }
 
-        [JsonProperty("userName")]
+        [JsonPropertyName("userName")]
         public string UserName { get; private set; }
 
-        [JsonProperty("mode")]
+        [JsonPropertyName("mode")]
         public string Mode { get; private set; }
 
-        [JsonProperty("ip")]
+        [JsonPropertyName("ip")]
         public string Ip { get; private set; }
 
-        [JsonProperty("time")]
+        [JsonPropertyName("time")]
         public string Time { get; private set; }
 
-        [JsonProperty("osCode")]
+        [JsonPropertyName("osCode")]
         public string OsCode { get; private set; }
 
-        [JsonProperty("osName")]
+        [JsonPropertyName("osName")]
         public string OsName { get; private set; }
 
-        [JsonProperty("osVersion")]
+        [JsonPropertyName("osVersion")]
         public string OsVersion { get; private set; }
 
-        [JsonProperty("clientType")]
+        [JsonPropertyName("clientType")]
         public string ClientType { get; private set; }
 
-        [JsonProperty("clientCode")]
+        [JsonPropertyName("clientCode")]
         public string ClientCode { get; private set; }
 
-        [JsonProperty("clientName")]
+        [JsonPropertyName("clientName")]
         public string ClientName { get; private set; }
 
-        [JsonProperty("clientVersion")]
+        [JsonPropertyName("clientVersion")]
         public string ClientVersion { get; private set; }
 
-        [JsonProperty("clientEngine")]
+        [JsonPropertyName("clientEngine")]
         public string ClientEngine { get; private set; }
 
-        [JsonProperty("clientEngineVersion")]
+        [JsonPropertyName("clientEngineVersion")]
         public string ClientEngineVersion { get; private set; }
 
-        [JsonProperty("deviceName")]
+        [JsonPropertyName("deviceName")]
         public string DeviceName { get; private set; }
 
-        [JsonProperty("deviceBrand")]
+        [JsonPropertyName("deviceBrand")]
         public string DeviceBrand { get; private set; }
 
-        [JsonProperty("deviceModel")]
+        [JsonPropertyName("deviceModel")]
         public string DeviceModel { get; private set; }
 
-        [JsonProperty("countryCode")]
+        [JsonPropertyName("countryCode")]
         public string CountryCode { get; private set; }
 
-        [JsonProperty("countryName")]
+        [JsonPropertyName("countryName")]
         public string CountryName { get; private set; }
 
         public Log(

--- a/Appwrite/Models/LogList.cs
+++ b/Appwrite/Models/LogList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class LogList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("logs")]
+        [JsonPropertyName("logs")]
         public List<Log> Logs { get; private set; }
 
         public LogList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static LogList From(Dictionary<string, object> map) => new LogList(
             total: Convert.ToInt64(map["total"]),
-            logs: ((JArray)map["logs"]).ToObject<List<Dictionary<string, object>>>().Select(it => Log.From(map: it)).ToList()
+            logs: map["logs"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Log.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["logs"]).Select(it => Log.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Membership.cs
+++ b/Appwrite/Models/Membership.cs
@@ -2,51 +2,50 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Membership
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("userId")]
+        [JsonPropertyName("userId")]
         public string UserId { get; private set; }
 
-        [JsonProperty("userName")]
+        [JsonPropertyName("userName")]
         public string UserName { get; private set; }
 
-        [JsonProperty("userEmail")]
+        [JsonPropertyName("userEmail")]
         public string UserEmail { get; private set; }
 
-        [JsonProperty("teamId")]
+        [JsonPropertyName("teamId")]
         public string TeamId { get; private set; }
 
-        [JsonProperty("teamName")]
+        [JsonPropertyName("teamName")]
         public string TeamName { get; private set; }
 
-        [JsonProperty("invited")]
+        [JsonPropertyName("invited")]
         public string Invited { get; private set; }
 
-        [JsonProperty("joined")]
+        [JsonPropertyName("joined")]
         public string Joined { get; private set; }
 
-        [JsonProperty("confirm")]
+        [JsonPropertyName("confirm")]
         public bool Confirm { get; private set; }
 
-        [JsonProperty("mfa")]
+        [JsonPropertyName("mfa")]
         public bool Mfa { get; private set; }
 
-        [JsonProperty("roles")]
+        [JsonPropertyName("roles")]
         public List<string> Roles { get; private set; }
 
         public Membership(
@@ -92,7 +91,7 @@ namespace Appwrite.Models
             joined: map["joined"].ToString(),
             confirm: (bool)map["confirm"],
             mfa: (bool)map["mfa"],
-            roles: ((JArray)map["roles"]).ToObject<List<string>>()
+            roles: map["roles"] is JsonElement jsonArrayProp13 ? jsonArrayProp13.Deserialize<List<string>>()! : (List<string>)map["roles"]
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/MembershipList.cs
+++ b/Appwrite/Models/MembershipList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class MembershipList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("memberships")]
+        [JsonPropertyName("memberships")]
         public List<Membership> Memberships { get; private set; }
 
         public MembershipList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static MembershipList From(Dictionary<string, object> map) => new MembershipList(
             total: Convert.ToInt64(map["total"]),
-            memberships: ((JArray)map["memberships"]).ToObject<List<Dictionary<string, object>>>().Select(it => Membership.From(map: it)).ToList()
+            memberships: map["memberships"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Membership.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["memberships"]).Select(it => Membership.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Message.cs
+++ b/Appwrite/Models/Message.cs
@@ -2,51 +2,50 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Message
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("providerType")]
+        [JsonPropertyName("providerType")]
         public string ProviderType { get; private set; }
 
-        [JsonProperty("topics")]
+        [JsonPropertyName("topics")]
         public List<string> Topics { get; private set; }
 
-        [JsonProperty("users")]
+        [JsonPropertyName("users")]
         public List<string> Users { get; private set; }
 
-        [JsonProperty("targets")]
+        [JsonPropertyName("targets")]
         public List<string> Targets { get; private set; }
 
-        [JsonProperty("scheduledAt")]
+        [JsonPropertyName("scheduledAt")]
         public string? ScheduledAt { get; private set; }
 
-        [JsonProperty("deliveredAt")]
+        [JsonPropertyName("deliveredAt")]
         public string? DeliveredAt { get; private set; }
 
-        [JsonProperty("deliveryErrors")]
+        [JsonPropertyName("deliveryErrors")]
         public List<string>? DeliveryErrors { get; private set; }
 
-        [JsonProperty("deliveredTotal")]
+        [JsonPropertyName("deliveredTotal")]
         public long DeliveredTotal { get; private set; }
 
-        [JsonProperty("data")]
+        [JsonPropertyName("data")]
         public object Data { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; private set; }
 
         public Message(
@@ -84,12 +83,12 @@ namespace Appwrite.Models
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
             providerType: map["providerType"].ToString(),
-            topics: ((JArray)map["topics"]).ToObject<List<string>>(),
-            users: ((JArray)map["users"]).ToObject<List<string>>(),
-            targets: ((JArray)map["targets"]).ToObject<List<string>>(),
+            topics: map["topics"] is JsonElement jsonArrayProp5 ? jsonArrayProp5.Deserialize<List<string>>()! : (List<string>)map["topics"],
+            users: map["users"] is JsonElement jsonArrayProp6 ? jsonArrayProp6.Deserialize<List<string>>()! : (List<string>)map["users"],
+            targets: map["targets"] is JsonElement jsonArrayProp7 ? jsonArrayProp7.Deserialize<List<string>>()! : (List<string>)map["targets"],
             scheduledAt: map.TryGetValue("scheduledAt", out var scheduledAt) ? scheduledAt?.ToString() : null,
             deliveredAt: map.TryGetValue("deliveredAt", out var deliveredAt) ? deliveredAt?.ToString() : null,
-            deliveryErrors: ((JArray)map["deliveryErrors"]).ToObject<List<string>>(),
+            deliveryErrors: map["deliveryErrors"] is JsonElement jsonArrayProp10 ? jsonArrayProp10.Deserialize<List<string>>()! : (List<string>)map["deliveryErrors"],
             deliveredTotal: Convert.ToInt64(map["deliveredTotal"]),
             data: map["data"].ToString(),
             status: map["status"].ToString()

--- a/Appwrite/Models/MessageList.cs
+++ b/Appwrite/Models/MessageList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class MessageList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("messages")]
+        [JsonPropertyName("messages")]
         public List<Message> Messages { get; private set; }
 
         public MessageList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static MessageList From(Dictionary<string, object> map) => new MessageList(
             total: Convert.ToInt64(map["total"]),
-            messages: ((JArray)map["messages"]).ToObject<List<Dictionary<string, object>>>().Select(it => Message.From(map: it)).ToList()
+            messages: map["messages"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Message.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["messages"]).Select(it => Message.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/MfaChallenge.cs
+++ b/Appwrite/Models/MfaChallenge.cs
@@ -2,24 +2,23 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class MfaChallenge
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("userId")]
+        [JsonPropertyName("userId")]
         public string UserId { get; private set; }
 
-        [JsonProperty("expire")]
+        [JsonPropertyName("expire")]
         public string Expire { get; private set; }
 
         public MfaChallenge(

--- a/Appwrite/Models/MfaFactors.cs
+++ b/Appwrite/Models/MfaFactors.cs
@@ -2,24 +2,23 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class MfaFactors
     {
-        [JsonProperty("totp")]
+        [JsonPropertyName("totp")]
         public bool Totp { get; private set; }
 
-        [JsonProperty("phone")]
+        [JsonPropertyName("phone")]
         public bool Phone { get; private set; }
 
-        [JsonProperty("email")]
+        [JsonPropertyName("email")]
         public bool Email { get; private set; }
 
-        [JsonProperty("recoveryCode")]
+        [JsonPropertyName("recoveryCode")]
         public bool RecoveryCode { get; private set; }
 
         public MfaFactors(

--- a/Appwrite/Models/MfaRecoveryCodes.cs
+++ b/Appwrite/Models/MfaRecoveryCodes.cs
@@ -2,15 +2,14 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class MfaRecoveryCodes
     {
-        [JsonProperty("recoveryCodes")]
+        [JsonPropertyName("recoveryCodes")]
         public List<string> RecoveryCodes { get; private set; }
 
         public MfaRecoveryCodes(
@@ -20,7 +19,7 @@ namespace Appwrite.Models
         }
 
         public static MfaRecoveryCodes From(Dictionary<string, object> map) => new MfaRecoveryCodes(
-            recoveryCodes: ((JArray)map["recoveryCodes"]).ToObject<List<string>>()
+            recoveryCodes: map["recoveryCodes"] is JsonElement jsonArrayProp1 ? jsonArrayProp1.Deserialize<List<string>>()! : (List<string>)map["recoveryCodes"]
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/MfaType.cs
+++ b/Appwrite/Models/MfaType.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class MfaType
     {
-        [JsonProperty("secret")]
+        [JsonPropertyName("secret")]
         public string Secret { get; private set; }
 
-        [JsonProperty("uri")]
+        [JsonPropertyName("uri")]
         public string Uri { get; private set; }
 
         public MfaType(

--- a/Appwrite/Models/Phone.cs
+++ b/Appwrite/Models/Phone.cs
@@ -2,21 +2,20 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Phone
     {
-        [JsonProperty("code")]
+        [JsonPropertyName("code")]
         public string Code { get; private set; }
 
-        [JsonProperty("countryCode")]
+        [JsonPropertyName("countryCode")]
         public string CountryCode { get; private set; }
 
-        [JsonProperty("countryName")]
+        [JsonPropertyName("countryName")]
         public string CountryName { get; private set; }
 
         public Phone(

--- a/Appwrite/Models/PhoneList.cs
+++ b/Appwrite/Models/PhoneList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class PhoneList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("phones")]
+        [JsonPropertyName("phones")]
         public List<Phone> Phones { get; private set; }
 
         public PhoneList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static PhoneList From(Dictionary<string, object> map) => new PhoneList(
             total: Convert.ToInt64(map["total"]),
-            phones: ((JArray)map["phones"]).ToObject<List<Dictionary<string, object>>>().Select(it => Phone.From(map: it)).ToList()
+            phones: map["phones"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Phone.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["phones"]).Select(it => Phone.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Preferences.cs
+++ b/Appwrite/Models/Preferences.cs
@@ -2,9 +2,8 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {

--- a/Appwrite/Models/Provider.cs
+++ b/Appwrite/Models/Provider.cs
@@ -2,39 +2,38 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Provider
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("provider")]
+        [JsonPropertyName("provider")]
         public string MessagingProvider { get; private set; }
 
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; private set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         public string Type { get; private set; }
 
-        [JsonProperty("credentials")]
+        [JsonPropertyName("credentials")]
         public object Credentials { get; private set; }
 
-        [JsonProperty("options")]
+        [JsonPropertyName("options")]
         public object? Options { get; private set; }
 
         public Provider(

--- a/Appwrite/Models/ProviderList.cs
+++ b/Appwrite/Models/ProviderList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class ProviderList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("providers")]
+        [JsonPropertyName("providers")]
         public List<Provider> Providers { get; private set; }
 
         public ProviderList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static ProviderList From(Dictionary<string, object> map) => new ProviderList(
             total: Convert.ToInt64(map["total"]),
-            providers: ((JArray)map["providers"]).ToObject<List<Dictionary<string, object>>>().Select(it => Provider.From(map: it)).ToList()
+            providers: map["providers"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Provider.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["providers"]).Select(it => Provider.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/ResourceToken.cs
+++ b/Appwrite/Models/ResourceToken.cs
@@ -2,33 +2,32 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class ResourceToken
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("resourceId")]
+        [JsonPropertyName("resourceId")]
         public string ResourceId { get; private set; }
 
-        [JsonProperty("resourceType")]
+        [JsonPropertyName("resourceType")]
         public string ResourceType { get; private set; }
 
-        [JsonProperty("expire")]
+        [JsonPropertyName("expire")]
         public string Expire { get; private set; }
 
-        [JsonProperty("secret")]
+        [JsonPropertyName("secret")]
         public string Secret { get; private set; }
 
-        [JsonProperty("accessedAt")]
+        [JsonPropertyName("accessedAt")]
         public string AccessedAt { get; private set; }
 
         public ResourceToken(

--- a/Appwrite/Models/ResourceTokenList.cs
+++ b/Appwrite/Models/ResourceTokenList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class ResourceTokenList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("tokens")]
+        [JsonPropertyName("tokens")]
         public List<ResourceToken> Tokens { get; private set; }
 
         public ResourceTokenList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static ResourceTokenList From(Dictionary<string, object> map) => new ResourceTokenList(
             total: Convert.ToInt64(map["total"]),
-            tokens: ((JArray)map["tokens"]).ToObject<List<Dictionary<string, object>>>().Select(it => ResourceToken.From(map: it)).ToList()
+            tokens: map["tokens"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => ResourceToken.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["tokens"]).Select(it => ResourceToken.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Runtime.cs
+++ b/Appwrite/Models/Runtime.cs
@@ -2,36 +2,35 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Runtime
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public string Version { get; private set; }
 
-        [JsonProperty("base")]
+        [JsonPropertyName("base")]
         public string Base { get; private set; }
 
-        [JsonProperty("image")]
+        [JsonPropertyName("image")]
         public string Image { get; private set; }
 
-        [JsonProperty("logo")]
+        [JsonPropertyName("logo")]
         public string Logo { get; private set; }
 
-        [JsonProperty("supports")]
+        [JsonPropertyName("supports")]
         public List<string> Supports { get; private set; }
 
         public Runtime(
@@ -62,7 +61,7 @@ namespace Appwrite.Models
             xbase: map["base"].ToString(),
             image: map["image"].ToString(),
             logo: map["logo"].ToString(),
-            supports: ((JArray)map["supports"]).ToObject<List<string>>()
+            supports: map["supports"] is JsonElement jsonArrayProp8 ? jsonArrayProp8.Deserialize<List<string>>()! : (List<string>)map["supports"]
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/RuntimeList.cs
+++ b/Appwrite/Models/RuntimeList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class RuntimeList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("runtimes")]
+        [JsonPropertyName("runtimes")]
         public List<Runtime> Runtimes { get; private set; }
 
         public RuntimeList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static RuntimeList From(Dictionary<string, object> map) => new RuntimeList(
             total: Convert.ToInt64(map["total"]),
-            runtimes: ((JArray)map["runtimes"]).ToObject<List<Dictionary<string, object>>>().Select(it => Runtime.From(map: it)).ToList()
+            runtimes: map["runtimes"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Runtime.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["runtimes"]).Select(it => Runtime.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Session.cs
+++ b/Appwrite/Models/Session.cs
@@ -2,99 +2,98 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Session
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("userId")]
+        [JsonPropertyName("userId")]
         public string UserId { get; private set; }
 
-        [JsonProperty("expire")]
+        [JsonPropertyName("expire")]
         public string Expire { get; private set; }
 
-        [JsonProperty("provider")]
+        [JsonPropertyName("provider")]
         public string Provider { get; private set; }
 
-        [JsonProperty("providerUid")]
+        [JsonPropertyName("providerUid")]
         public string ProviderUid { get; private set; }
 
-        [JsonProperty("providerAccessToken")]
+        [JsonPropertyName("providerAccessToken")]
         public string ProviderAccessToken { get; private set; }
 
-        [JsonProperty("providerAccessTokenExpiry")]
+        [JsonPropertyName("providerAccessTokenExpiry")]
         public string ProviderAccessTokenExpiry { get; private set; }
 
-        [JsonProperty("providerRefreshToken")]
+        [JsonPropertyName("providerRefreshToken")]
         public string ProviderRefreshToken { get; private set; }
 
-        [JsonProperty("ip")]
+        [JsonPropertyName("ip")]
         public string Ip { get; private set; }
 
-        [JsonProperty("osCode")]
+        [JsonPropertyName("osCode")]
         public string OsCode { get; private set; }
 
-        [JsonProperty("osName")]
+        [JsonPropertyName("osName")]
         public string OsName { get; private set; }
 
-        [JsonProperty("osVersion")]
+        [JsonPropertyName("osVersion")]
         public string OsVersion { get; private set; }
 
-        [JsonProperty("clientType")]
+        [JsonPropertyName("clientType")]
         public string ClientType { get; private set; }
 
-        [JsonProperty("clientCode")]
+        [JsonPropertyName("clientCode")]
         public string ClientCode { get; private set; }
 
-        [JsonProperty("clientName")]
+        [JsonPropertyName("clientName")]
         public string ClientName { get; private set; }
 
-        [JsonProperty("clientVersion")]
+        [JsonPropertyName("clientVersion")]
         public string ClientVersion { get; private set; }
 
-        [JsonProperty("clientEngine")]
+        [JsonPropertyName("clientEngine")]
         public string ClientEngine { get; private set; }
 
-        [JsonProperty("clientEngineVersion")]
+        [JsonPropertyName("clientEngineVersion")]
         public string ClientEngineVersion { get; private set; }
 
-        [JsonProperty("deviceName")]
+        [JsonPropertyName("deviceName")]
         public string DeviceName { get; private set; }
 
-        [JsonProperty("deviceBrand")]
+        [JsonPropertyName("deviceBrand")]
         public string DeviceBrand { get; private set; }
 
-        [JsonProperty("deviceModel")]
+        [JsonPropertyName("deviceModel")]
         public string DeviceModel { get; private set; }
 
-        [JsonProperty("countryCode")]
+        [JsonPropertyName("countryCode")]
         public string CountryCode { get; private set; }
 
-        [JsonProperty("countryName")]
+        [JsonPropertyName("countryName")]
         public string CountryName { get; private set; }
 
-        [JsonProperty("current")]
+        [JsonPropertyName("current")]
         public bool Current { get; private set; }
 
-        [JsonProperty("factors")]
+        [JsonPropertyName("factors")]
         public List<string> Factors { get; private set; }
 
-        [JsonProperty("secret")]
+        [JsonPropertyName("secret")]
         public string Secret { get; private set; }
 
-        [JsonProperty("mfaUpdatedAt")]
+        [JsonPropertyName("mfaUpdatedAt")]
         public string MfaUpdatedAt { get; private set; }
 
         public Session(
@@ -186,7 +185,7 @@ namespace Appwrite.Models
             countryCode: map["countryCode"].ToString(),
             countryName: map["countryName"].ToString(),
             current: (bool)map["current"],
-            factors: ((JArray)map["factors"]).ToObject<List<string>>(),
+            factors: map["factors"] is JsonElement jsonArrayProp27 ? jsonArrayProp27.Deserialize<List<string>>()! : (List<string>)map["factors"],
             secret: map["secret"].ToString(),
             mfaUpdatedAt: map["mfaUpdatedAt"].ToString()
         );

--- a/Appwrite/Models/SessionList.cs
+++ b/Appwrite/Models/SessionList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class SessionList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("sessions")]
+        [JsonPropertyName("sessions")]
         public List<Session> Sessions { get; private set; }
 
         public SessionList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static SessionList From(Dictionary<string, object> map) => new SessionList(
             total: Convert.ToInt64(map["total"]),
-            sessions: ((JArray)map["sessions"]).ToObject<List<Dictionary<string, object>>>().Select(it => Session.From(map: it)).ToList()
+            sessions: map["sessions"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Session.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["sessions"]).Select(it => Session.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Site.cs
+++ b/Appwrite/Models/Site.cs
@@ -2,99 +2,98 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Site
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; private set; }
 
-        [JsonProperty("live")]
+        [JsonPropertyName("live")]
         public bool Live { get; private set; }
 
-        [JsonProperty("logging")]
+        [JsonPropertyName("logging")]
         public bool Logging { get; private set; }
 
-        [JsonProperty("framework")]
+        [JsonPropertyName("framework")]
         public string Framework { get; private set; }
 
-        [JsonProperty("deploymentId")]
+        [JsonPropertyName("deploymentId")]
         public string DeploymentId { get; private set; }
 
-        [JsonProperty("deploymentCreatedAt")]
+        [JsonPropertyName("deploymentCreatedAt")]
         public string DeploymentCreatedAt { get; private set; }
 
-        [JsonProperty("deploymentScreenshotLight")]
+        [JsonPropertyName("deploymentScreenshotLight")]
         public string DeploymentScreenshotLight { get; private set; }
 
-        [JsonProperty("deploymentScreenshotDark")]
+        [JsonPropertyName("deploymentScreenshotDark")]
         public string DeploymentScreenshotDark { get; private set; }
 
-        [JsonProperty("latestDeploymentId")]
+        [JsonPropertyName("latestDeploymentId")]
         public string LatestDeploymentId { get; private set; }
 
-        [JsonProperty("latestDeploymentCreatedAt")]
+        [JsonPropertyName("latestDeploymentCreatedAt")]
         public string LatestDeploymentCreatedAt { get; private set; }
 
-        [JsonProperty("latestDeploymentStatus")]
+        [JsonPropertyName("latestDeploymentStatus")]
         public string LatestDeploymentStatus { get; private set; }
 
-        [JsonProperty("vars")]
+        [JsonPropertyName("vars")]
         public List<Variable> Vars { get; private set; }
 
-        [JsonProperty("timeout")]
+        [JsonPropertyName("timeout")]
         public long Timeout { get; private set; }
 
-        [JsonProperty("installCommand")]
+        [JsonPropertyName("installCommand")]
         public string InstallCommand { get; private set; }
 
-        [JsonProperty("buildCommand")]
+        [JsonPropertyName("buildCommand")]
         public string BuildCommand { get; private set; }
 
-        [JsonProperty("outputDirectory")]
+        [JsonPropertyName("outputDirectory")]
         public string OutputDirectory { get; private set; }
 
-        [JsonProperty("installationId")]
+        [JsonPropertyName("installationId")]
         public string InstallationId { get; private set; }
 
-        [JsonProperty("providerRepositoryId")]
+        [JsonPropertyName("providerRepositoryId")]
         public string ProviderRepositoryId { get; private set; }
 
-        [JsonProperty("providerBranch")]
+        [JsonPropertyName("providerBranch")]
         public string ProviderBranch { get; private set; }
 
-        [JsonProperty("providerRootDirectory")]
+        [JsonPropertyName("providerRootDirectory")]
         public string ProviderRootDirectory { get; private set; }
 
-        [JsonProperty("providerSilentMode")]
+        [JsonPropertyName("providerSilentMode")]
         public bool ProviderSilentMode { get; private set; }
 
-        [JsonProperty("specification")]
+        [JsonPropertyName("specification")]
         public string Specification { get; private set; }
 
-        [JsonProperty("buildRuntime")]
+        [JsonPropertyName("buildRuntime")]
         public string BuildRuntime { get; private set; }
 
-        [JsonProperty("adapter")]
+        [JsonPropertyName("adapter")]
         public string Adapter { get; private set; }
 
-        [JsonProperty("fallbackFile")]
+        [JsonPropertyName("fallbackFile")]
         public string FallbackFile { get; private set; }
 
         public Site(
@@ -175,7 +174,7 @@ namespace Appwrite.Models
             latestDeploymentId: map["latestDeploymentId"].ToString(),
             latestDeploymentCreatedAt: map["latestDeploymentCreatedAt"].ToString(),
             latestDeploymentStatus: map["latestDeploymentStatus"].ToString(),
-            vars: ((JArray)map["vars"]).ToObject<List<Dictionary<string, object>>>().Select(it => Variable.From(map: it)).ToList(),
+            vars: map["vars"] is JsonElement jsonArray16 ? jsonArray16.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Variable.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["vars"]).Select(it => Variable.From(map: it)).ToList(),
             timeout: Convert.ToInt64(map["timeout"]),
             installCommand: map["installCommand"].ToString(),
             buildCommand: map["buildCommand"].ToString(),

--- a/Appwrite/Models/SiteList.cs
+++ b/Appwrite/Models/SiteList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class SiteList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("sites")]
+        [JsonPropertyName("sites")]
         public List<Site> Sites { get; private set; }
 
         public SiteList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static SiteList From(Dictionary<string, object> map) => new SiteList(
             total: Convert.ToInt64(map["total"]),
-            sites: ((JArray)map["sites"]).ToObject<List<Dictionary<string, object>>>().Select(it => Site.From(map: it)).ToList()
+            sites: map["sites"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Site.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["sites"]).Select(it => Site.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Specification.cs
+++ b/Appwrite/Models/Specification.cs
@@ -2,24 +2,23 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Specification
     {
-        [JsonProperty("memory")]
+        [JsonPropertyName("memory")]
         public long Memory { get; private set; }
 
-        [JsonProperty("cpus")]
+        [JsonPropertyName("cpus")]
         public double Cpus { get; private set; }
 
-        [JsonProperty("enabled")]
+        [JsonPropertyName("enabled")]
         public bool Enabled { get; private set; }
 
-        [JsonProperty("slug")]
+        [JsonPropertyName("slug")]
         public string Slug { get; private set; }
 
         public Specification(

--- a/Appwrite/Models/SpecificationList.cs
+++ b/Appwrite/Models/SpecificationList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class SpecificationList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("specifications")]
+        [JsonPropertyName("specifications")]
         public List<Specification> Specifications { get; private set; }
 
         public SpecificationList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static SpecificationList From(Dictionary<string, object> map) => new SpecificationList(
             total: Convert.ToInt64(map["total"]),
-            specifications: ((JArray)map["specifications"]).ToObject<List<Dictionary<string, object>>>().Select(it => Specification.From(map: it)).ToList()
+            specifications: map["specifications"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Specification.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["specifications"]).Select(it => Specification.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Subscriber.cs
+++ b/Appwrite/Models/Subscriber.cs
@@ -2,39 +2,38 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Subscriber
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("targetId")]
+        [JsonPropertyName("targetId")]
         public string TargetId { get; private set; }
 
-        [JsonProperty("target")]
+        [JsonPropertyName("target")]
         public Target Target { get; private set; }
 
-        [JsonProperty("userId")]
+        [JsonPropertyName("userId")]
         public string UserId { get; private set; }
 
-        [JsonProperty("userName")]
+        [JsonPropertyName("userName")]
         public string UserName { get; private set; }
 
-        [JsonProperty("topicId")]
+        [JsonPropertyName("topicId")]
         public string TopicId { get; private set; }
 
-        [JsonProperty("providerType")]
+        [JsonPropertyName("providerType")]
         public string ProviderType { get; private set; }
 
         public Subscriber(
@@ -64,7 +63,7 @@ namespace Appwrite.Models
             createdAt: map["$createdAt"].ToString(),
             updatedAt: map["$updatedAt"].ToString(),
             targetId: map["targetId"].ToString(),
-            target: Target.From(map: ((JObject)map["target"]).ToObject<Dictionary<string, object>>()!),
+            target: Target.From(map: map["target"] is JsonElement jsonObj5 ? jsonObj5.Deserialize<Dictionary<string, object>>()! : (Dictionary<string, object>)map["target"]),
             userId: map["userId"].ToString(),
             userName: map["userName"].ToString(),
             topicId: map["topicId"].ToString(),

--- a/Appwrite/Models/SubscriberList.cs
+++ b/Appwrite/Models/SubscriberList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class SubscriberList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("subscribers")]
+        [JsonPropertyName("subscribers")]
         public List<Subscriber> Subscribers { get; private set; }
 
         public SubscriberList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static SubscriberList From(Dictionary<string, object> map) => new SubscriberList(
             total: Convert.ToInt64(map["total"]),
-            subscribers: ((JArray)map["subscribers"]).ToObject<List<Dictionary<string, object>>>().Select(it => Subscriber.From(map: it)).ToList()
+            subscribers: map["subscribers"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Subscriber.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["subscribers"]).Select(it => Subscriber.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Target.cs
+++ b/Appwrite/Models/Target.cs
@@ -2,39 +2,38 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Target
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("userId")]
+        [JsonPropertyName("userId")]
         public string UserId { get; private set; }
 
-        [JsonProperty("providerId")]
+        [JsonPropertyName("providerId")]
         public string? ProviderId { get; private set; }
 
-        [JsonProperty("providerType")]
+        [JsonPropertyName("providerType")]
         public string ProviderType { get; private set; }
 
-        [JsonProperty("identifier")]
+        [JsonPropertyName("identifier")]
         public string Identifier { get; private set; }
 
-        [JsonProperty("expired")]
+        [JsonPropertyName("expired")]
         public bool Expired { get; private set; }
 
         public Target(

--- a/Appwrite/Models/TargetList.cs
+++ b/Appwrite/Models/TargetList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class TargetList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("targets")]
+        [JsonPropertyName("targets")]
         public List<Target> Targets { get; private set; }
 
         public TargetList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static TargetList From(Dictionary<string, object> map) => new TargetList(
             total: Convert.ToInt64(map["total"]),
-            targets: ((JArray)map["targets"]).ToObject<List<Dictionary<string, object>>>().Select(it => Target.From(map: it)).ToList()
+            targets: map["targets"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Target.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["targets"]).Select(it => Target.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Team.cs
+++ b/Appwrite/Models/Team.cs
@@ -2,30 +2,29 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Team
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("prefs")]
+        [JsonPropertyName("prefs")]
         public Preferences Prefs { get; private set; }
 
         public Team(
@@ -50,7 +49,7 @@ namespace Appwrite.Models
             updatedAt: map["$updatedAt"].ToString(),
             name: map["name"].ToString(),
             total: Convert.ToInt64(map["total"]),
-            prefs: Preferences.From(map: ((JObject)map["prefs"]).ToObject<Dictionary<string, object>>()!)
+            prefs: Preferences.From(map: map["prefs"] is JsonElement jsonObj6 ? jsonObj6.Deserialize<Dictionary<string, object>>()! : (Dictionary<string, object>)map["prefs"])
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/TeamList.cs
+++ b/Appwrite/Models/TeamList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class TeamList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("teams")]
+        [JsonPropertyName("teams")]
         public List<Team> Teams { get; private set; }
 
         public TeamList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static TeamList From(Dictionary<string, object> map) => new TeamList(
             total: Convert.ToInt64(map["total"]),
-            teams: ((JArray)map["teams"]).ToObject<List<Dictionary<string, object>>>().Select(it => Team.From(map: it)).ToList()
+            teams: map["teams"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Team.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["teams"]).Select(it => Team.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Token.cs
+++ b/Appwrite/Models/Token.cs
@@ -2,30 +2,29 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Token
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("userId")]
+        [JsonPropertyName("userId")]
         public string UserId { get; private set; }
 
-        [JsonProperty("secret")]
+        [JsonPropertyName("secret")]
         public string Secret { get; private set; }
 
-        [JsonProperty("expire")]
+        [JsonPropertyName("expire")]
         public string Expire { get; private set; }
 
-        [JsonProperty("phrase")]
+        [JsonPropertyName("phrase")]
         public string Phrase { get; private set; }
 
         public Token(

--- a/Appwrite/Models/Topic.cs
+++ b/Appwrite/Models/Topic.cs
@@ -2,36 +2,35 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Topic
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("emailTotal")]
+        [JsonPropertyName("emailTotal")]
         public long EmailTotal { get; private set; }
 
-        [JsonProperty("smsTotal")]
+        [JsonPropertyName("smsTotal")]
         public long SmsTotal { get; private set; }
 
-        [JsonProperty("pushTotal")]
+        [JsonPropertyName("pushTotal")]
         public long PushTotal { get; private set; }
 
-        [JsonProperty("subscribe")]
+        [JsonPropertyName("subscribe")]
         public List<string> Subscribe { get; private set; }
 
         public Topic(
@@ -62,7 +61,7 @@ namespace Appwrite.Models
             emailTotal: Convert.ToInt64(map["emailTotal"]),
             smsTotal: Convert.ToInt64(map["smsTotal"]),
             pushTotal: Convert.ToInt64(map["pushTotal"]),
-            subscribe: ((JArray)map["subscribe"]).ToObject<List<string>>()
+            subscribe: map["subscribe"] is JsonElement jsonArrayProp8 ? jsonArrayProp8.Deserialize<List<string>>()! : (List<string>)map["subscribe"]
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/TopicList.cs
+++ b/Appwrite/Models/TopicList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class TopicList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("topics")]
+        [JsonPropertyName("topics")]
         public List<Topic> Topics { get; private set; }
 
         public TopicList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static TopicList From(Dictionary<string, object> map) => new TopicList(
             total: Convert.ToInt64(map["total"]),
-            topics: ((JArray)map["topics"]).ToObject<List<Dictionary<string, object>>>().Select(it => Topic.From(map: it)).ToList()
+            topics: map["topics"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Topic.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["topics"]).Select(it => Topic.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/User.cs
+++ b/Appwrite/Models/User.cs
@@ -2,69 +2,68 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class User
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; private set; }
 
-        [JsonProperty("password")]
+        [JsonPropertyName("password")]
         public string? Password { get; private set; }
 
-        [JsonProperty("hash")]
+        [JsonPropertyName("hash")]
         public string? Hash { get; private set; }
 
-        [JsonProperty("hashOptions")]
+        [JsonPropertyName("hashOptions")]
         public object? HashOptions { get; private set; }
 
-        [JsonProperty("registration")]
+        [JsonPropertyName("registration")]
         public string Registration { get; private set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public bool Status { get; private set; }
 
-        [JsonProperty("labels")]
+        [JsonPropertyName("labels")]
         public List<string> Labels { get; private set; }
 
-        [JsonProperty("passwordUpdate")]
+        [JsonPropertyName("passwordUpdate")]
         public string PasswordUpdate { get; private set; }
 
-        [JsonProperty("email")]
+        [JsonPropertyName("email")]
         public string Email { get; private set; }
 
-        [JsonProperty("phone")]
+        [JsonPropertyName("phone")]
         public string Phone { get; private set; }
 
-        [JsonProperty("emailVerification")]
+        [JsonPropertyName("emailVerification")]
         public bool EmailVerification { get; private set; }
 
-        [JsonProperty("phoneVerification")]
+        [JsonPropertyName("phoneVerification")]
         public bool PhoneVerification { get; private set; }
 
-        [JsonProperty("mfa")]
+        [JsonPropertyName("mfa")]
         public bool Mfa { get; private set; }
 
-        [JsonProperty("prefs")]
+        [JsonPropertyName("prefs")]
         public Preferences Prefs { get; private set; }
 
-        [JsonProperty("targets")]
+        [JsonPropertyName("targets")]
         public List<Target> Targets { get; private set; }
 
-        [JsonProperty("accessedAt")]
+        [JsonPropertyName("accessedAt")]
         public string AccessedAt { get; private set; }
 
         public User(
@@ -119,15 +118,15 @@ namespace Appwrite.Models
             hashOptions: map.TryGetValue("hashOptions", out var hashOptions) ? hashOptions?.ToString() : null,
             registration: map["registration"].ToString(),
             status: (bool)map["status"],
-            labels: ((JArray)map["labels"]).ToObject<List<string>>(),
+            labels: map["labels"] is JsonElement jsonArrayProp10 ? jsonArrayProp10.Deserialize<List<string>>()! : (List<string>)map["labels"],
             passwordUpdate: map["passwordUpdate"].ToString(),
             email: map["email"].ToString(),
             phone: map["phone"].ToString(),
             emailVerification: (bool)map["emailVerification"],
             phoneVerification: (bool)map["phoneVerification"],
             mfa: (bool)map["mfa"],
-            prefs: Preferences.From(map: ((JObject)map["prefs"]).ToObject<Dictionary<string, object>>()!),
-            targets: ((JArray)map["targets"]).ToObject<List<Dictionary<string, object>>>().Select(it => Target.From(map: it)).ToList(),
+            prefs: Preferences.From(map: map["prefs"] is JsonElement jsonObj17 ? jsonObj17.Deserialize<Dictionary<string, object>>()! : (Dictionary<string, object>)map["prefs"]),
+            targets: map["targets"] is JsonElement jsonArray18 ? jsonArray18.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Target.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["targets"]).Select(it => Target.From(map: it)).ToList(),
             accessedAt: map["accessedAt"].ToString()
         );
 

--- a/Appwrite/Models/UserList.cs
+++ b/Appwrite/Models/UserList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class UserList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("users")]
+        [JsonPropertyName("users")]
         public List<User> Users { get; private set; }
 
         public UserList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static UserList From(Dictionary<string, object> map) => new UserList(
             total: Convert.ToInt64(map["total"]),
-            users: ((JArray)map["users"]).ToObject<List<Dictionary<string, object>>>().Select(it => User.From(map: it)).ToList()
+            users: map["users"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => User.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["users"]).Select(it => User.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/Variable.cs
+++ b/Appwrite/Models/Variable.cs
@@ -2,36 +2,35 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class Variable
     {
-        [JsonProperty("$id")]
+        [JsonPropertyName("$id")]
         public string Id { get; private set; }
 
-        [JsonProperty("$createdAt")]
+        [JsonPropertyName("$createdAt")]
         public string CreatedAt { get; private set; }
 
-        [JsonProperty("$updatedAt")]
+        [JsonPropertyName("$updatedAt")]
         public string UpdatedAt { get; private set; }
 
-        [JsonProperty("key")]
+        [JsonPropertyName("key")]
         public string Key { get; private set; }
 
-        [JsonProperty("value")]
+        [JsonPropertyName("value")]
         public string Value { get; private set; }
 
-        [JsonProperty("secret")]
+        [JsonPropertyName("secret")]
         public bool Secret { get; private set; }
 
-        [JsonProperty("resourceType")]
+        [JsonPropertyName("resourceType")]
         public string ResourceType { get; private set; }
 
-        [JsonProperty("resourceId")]
+        [JsonPropertyName("resourceId")]
         public string ResourceId { get; private set; }
 
         public Variable(

--- a/Appwrite/Models/VariableList.cs
+++ b/Appwrite/Models/VariableList.cs
@@ -2,18 +2,17 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Appwrite.Models
 {
     public class VariableList
     {
-        [JsonProperty("total")]
+        [JsonPropertyName("total")]
         public long Total { get; private set; }
 
-        [JsonProperty("variables")]
+        [JsonPropertyName("variables")]
         public List<Variable> Variables { get; private set; }
 
         public VariableList(
@@ -26,7 +25,7 @@ namespace Appwrite.Models
 
         public static VariableList From(Dictionary<string, object> map) => new VariableList(
             total: Convert.ToInt64(map["total"]),
-            variables: ((JArray)map["variables"]).ToObject<List<Dictionary<string, object>>>().Select(it => Variable.From(map: it)).ToList()
+            variables: map["variables"] is JsonElement jsonArray2 ? jsonArray2.Deserialize<List<Dictionary<string, object>>>()!.Select(it => Variable.From(map: it)).ToList() : ((IEnumerable<Dictionary<string, object>>)map["variables"]).Select(it => Variable.From(map: it)).ToList()
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Query.cs
+++ b/Appwrite/Query.cs
@@ -1,39 +1,49 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 
 namespace Appwrite
 {
     public class Query
     {
-        public string method;
-        public string? attribute;
-        public List<object>? values;
+        [JsonPropertyName("method")]
+        public string Method { get; set; } = string.Empty;
+        
+        [JsonPropertyName("attribute")]
+        public string? Attribute { get; set; }
+        
+        [JsonPropertyName("values")]
+        public List<object>? Values { get; set; }
+
+        public Query()
+        {
+        }
 
         public Query(string method, string? attribute, object? values)
         {
-            this.method = method;
-            this.attribute = attribute;
+            this.Method = method;
+            this.Attribute = attribute;
 
             if (values is IList valuesList)
             {
-                this.values = new List<object>();
+                this.Values = new List<object>();
                 foreach (var value in valuesList)
                 {
-                    this.values.Add(value); // Automatically boxes if value is a value type
+                    this.Values.Add(value); // Automatically boxes if value is a value type
                 }
             }
             else if (values != null)
             {
-                this.values = new List<object> { values };
+                this.Values = new List<object> { values };
             }
         }
 
         override public string ToString()
         {
-            return JsonConvert.SerializeObject(this);
+            return JsonSerializer.Serialize(this, Client.SerializerOptions);
         }
 
         public static string Equal(string attribute, object value)
@@ -141,11 +151,11 @@ namespace Appwrite
         }
 
         public static string Or(List<string> queries) {
-            return new Query("or", null, queries.Select(q => JsonConvert.DeserializeObject<Query>(q)).ToList()).ToString();
+            return new Query("or", null, queries.Select(q => JsonSerializer.Deserialize<Query>(q, Client.DeserializerOptions)).ToList()).ToString();
         }
 
         public static string And(List<string> queries) {
-            return new Query("and", null, queries.Select(q => JsonConvert.DeserializeObject<Query>(q)).ToList()).ToString();
+            return new Query("and", null, queries.Select(q => JsonSerializer.Deserialize<Query>(q, Client.DeserializerOptions)).ToList()).ToString();
         }
     }
 }

--- a/Appwrite/Services/Databases.cs
+++ b/Appwrite/Services/Databases.cs
@@ -1271,6 +1271,10 @@ namespace Appwrite.Services
         }
 
         /// <para>
+        /// **WARNING: Experimental Feature** - This endpoint is experimental and not
+        /// yet officially supported. It may be subject to breaking changes or removal
+        /// in future versions.
+        /// 
         /// Create new Documents. Before using this route, you should create a new
         /// collection resource using either a [server
         /// integration](https://appwrite.io/docs/server/databases#databasesCreateCollection)
@@ -1307,14 +1311,17 @@ namespace Appwrite.Services
         }
 
         /// <para>
+        /// **WARNING: Experimental Feature** - This endpoint is experimental and not
+        /// yet officially supported. It may be subject to breaking changes or removal
+        /// in future versions.
+        /// 
         /// Create or update Documents. Before using this route, you should create a
         /// new collection resource using either a [server
         /// integration](https://appwrite.io/docs/server/databases#databasesCreateCollection)
         /// API or directly from your database console.
-        /// 
         /// </para>
         /// </summary>
-        public Task<Models.DocumentList> UpsertDocuments(string databaseId, string collectionId, List<object>? documents = null)
+        public Task<Models.DocumentList> UpsertDocuments(string databaseId, string collectionId, List<object> documents)
         {
             var apiPath = "/databases/{databaseId}/collections/{collectionId}/documents"
                 .Replace("{databaseId}", databaseId)
@@ -1344,6 +1351,10 @@ namespace Appwrite.Services
         }
 
         /// <para>
+        /// **WARNING: Experimental Feature** - This endpoint is experimental and not
+        /// yet officially supported. It may be subject to breaking changes or removal
+        /// in future versions.
+        /// 
         /// Update all documents that match your queries, if no queries are submitted
         /// then all documents are updated. You can pass only specific fields to be
         /// updated.
@@ -1380,6 +1391,10 @@ namespace Appwrite.Services
         }
 
         /// <para>
+        /// **WARNING: Experimental Feature** - This endpoint is experimental and not
+        /// yet officially supported. It may be subject to breaking changes or removal
+        /// in future versions.
+        /// 
         /// Bulk delete documents using queries, if no queries are passed then all
         /// documents are deleted.
         /// </para>
@@ -1440,6 +1455,48 @@ namespace Appwrite.Services
 
             return _client.Call<Models.Document>(
                 method: "GET",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// **WARNING: Experimental Feature** - This endpoint is experimental and not
+        /// yet officially supported. It may be subject to breaking changes or removal
+        /// in future versions.
+        /// 
+        /// Create or update a Document. Before using this route, you should create a
+        /// new collection resource using either a [server
+        /// integration](https://appwrite.io/docs/server/databases#databasesCreateCollection)
+        /// API or directly from your database console.
+        /// </para>
+        /// </summary>
+        public Task<Models.Document> UpsertDocument(string databaseId, string collectionId, string documentId, object data, List<string>? permissions = null)
+        {
+            var apiPath = "/databases/{databaseId}/collections/{collectionId}/documents/{documentId}"
+                .Replace("{databaseId}", databaseId)
+                .Replace("{collectionId}", collectionId)
+                .Replace("{documentId}", documentId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "data", data },
+                { "permissions", permissions }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.Document Convert(Dictionary<string, object> it) =>
+                Models.Document.From(map: it);
+
+            return _client.Call<Models.Document>(
+                method: "PUT",
                 path: apiPath,
                 headers: apiHeaders,
                 parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,

--- a/Appwrite/Services/Tokens.cs
+++ b/Appwrite/Services/Tokens.cs
@@ -49,7 +49,7 @@ namespace Appwrite.Services
 
         /// <para>
         /// Create a new token. A token is linked to a file. Token can be passed as a
-        /// header or request get parameter.
+        /// request URL search parameter.
         /// </para>
         /// </summary>
         public Task<Models.ResourceToken> CreateFileToken(string bucketId, string fileId, string? expire = null)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,53 @@
 # Change Log
+
+## 0.13.0
+
+* Add `<REGION>` to doc examples due to the new multi region endpoints
+* Add doc examples and methods for bulk api transactions: `createDocuments`, `deleteDocuments` etc.
+* Add doc examples, class and methods for new `Sites` service
+* Add doc examples, class and methods for new `Tokens` service
+* Add enums for `BuildRuntime `, `Adapter`, `Framework`, `DeploymentDownloadType` and `VCSDeploymentType`
+* Update enum for `runtimes` with Pythonml312, Dart219, Flutter327 and Flutter329
+* Add `token` param to `getFilePreview` and `getFileView` for File tokens usage
+* Add `queries` and `search` params to `listMemberships` method
+* Remove `search` param from `listExecutions` method
+
+## 0.12.0
+
+* fix: remove content-type from GET requests by @loks0n in https://github.com/appwrite/sdk-for-dotnet/pull/59
+* update: min and max are not optional in methods like `UpdateIntegerAttribute` etc.
+* chore: regenerate sdk by @ChiragAgg5k in https://github.com/appwrite/sdk-for-dotnet/pull/60
+* chore: fix build error by @ChiragAgg5k in https://github.com/appwrite/sdk-for-dotnet/pull/61
+
+## 0.11.0
+
+* Add new push message parameters by @abnegate in https://github.com/appwrite/sdk-for-dotnet/pull/56
+
+## 0.10.0
+
+* fix: chunk upload by @byawitz in https://github.com/appwrite/sdk-for-dotnet/pull/52
+
+## 0.9.0
+
+* Support for Appwrite 1.6
+* Added `key` attribute to `Runtime` response model.
+* Added `buildSize` attribute to `Deployments` response model.
+* Added `scheduledAt` attribute to `Executions` response model.
+* Added `scopes` attribute to `Functions` response model.
+* Added `specifications` attribute to `Functions` response model.
+* Added new response model for `Specifications`.
+* Added new response model for `Builds`.
+* Added `createJWT()` : Enables creating a JWT using the `userId`.
+* Added `listSpecifications()`: Enables listing available runtime specifications.
+* Added `deleteExecution()` : Enables deleting executions.
+* Added `updateDeploymentBuild()`: Enables cancelling a deployment.
+* Added `scheduledAt` parameter to `createExecution()`: Enables creating a delayed execution
+
+#### Breaking changes
+You can find the new syntax for breaking changes in the [Appwrite API references](https://appwrite.io/docs/references). Select version `1.6.x`.
+* Removed `otp` parameter from `deleteMFAAuthenticator`.
+* Added `scopes` parameter for create/update function.
+* Renamed `templateBranch` to `templateVersion`  in `createFunction()`.
+* Renamed `downloadDeployment()` to `getDeploymentDownload()`
+
+> **Please note: This version is compatible with Appwrite 1.6 and later only. If you do not update your Appwrite SDK, old SDKs will not break your app. Appwrite APIs are backwards compatible.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## 0.14.0
+
+* Refactor from Newtonsoft.Json to System.Text.Json for serialization/deserialization
+* Update package dependencies in `Package.csproj.twig`
+* Migrate all serialization/deserialization logic in `Client.cs.twig`, `Query.cs.twig`, and `Extensions.cs.twig`
+* Update model attributes from `[JsonProperty]` to `[JsonPropertyName]` in `Model.cs.twig`
+* Create new `ObjectToInferredTypesConverter.cs.twig` for proper object type handling
+* Replace `JsonConverter` with `JsonConverter<object>` in `ValueClassConverter.cs.twig`
+* Update error handling to use `JsonDocument` instead of `JObject`
+
 ## 0.13.0
 
 * Add `<REGION>` to doc examples due to the new multi region endpoints

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Appwrite .NET SDK
 
 ![License](https://img.shields.io/github/license/appwrite/sdk-for-dotnet.svg?style=flat-square)
-![Version](https://img.shields.io/badge/api%20version-1.7.0-blue.svg?style=flat-square)
+![Version](https://img.shields.io/badge/api%20version-1.7.4-blue.svg?style=flat-square)
 [![Build Status](https://img.shields.io/travis/com/appwrite/sdk-generator?style=flat-square)](https://travis-ci.com/appwrite/sdk-generator)
 [![Twitter Account](https://img.shields.io/twitter/follow/appwrite?color=00acee&label=twitter&style=flat-square)](https://twitter.com/appwrite)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord)
@@ -17,17 +17,17 @@ Appwrite is an open-source backend as a service server that abstract and simplif
 Add this reference to your project's `.csproj` file:
 
 ```xml
-<PackageReference Include="Appwrite" Version="0.13.0" />
+<PackageReference Include="Appwrite" Version="0.14.0" />
 ```
 
 You can install packages from the command line:
 
 ```powershell
 # Package Manager
-Install-Package Appwrite -Version 0.13.0
+Install-Package Appwrite -Version 0.14.0
 
 # or .NET CLI
-dotnet add package Appwrite --version 0.13.0
+dotnet add package Appwrite --version 0.14.0
 ```
 
 
@@ -90,24 +90,24 @@ You can use the following resources to learn more and get help
 
 ### Preparing Models for Databases API
 
-For the .NET SDK, we use the `Newtonsoft.Json` library for serialization/deserialization support. The default behavior converts property names from `PascalCase` to `camelCase` on serializing to JSON. In case the names of attributes in your Appwrite collection are not created in `camelCase`, this serializer behavior can cause errors due to mismatches in the names in the serialized JSON and the actual attribute names in your collection.
+For the .NET SDK, we use the `System.Text.Json` library for serialization/deserialization support. The default behavior converts property names from `PascalCase` to `camelCase` on serializing to JSON. In case the names of attributes in your Appwrite collection are not created in `camelCase`, this serializer behavior can cause errors due to mismatches in the names in the serialized JSON and the actual attribute names in your collection.
 
-The way to fix this is to add the `JsonProperty` attribute to the properties in the POCO class you create for your model.
+The way to fix this is to add the `JsonPropertyName` attribute to the properties in the POCO class you create for your model.
 
 For e.g., if you have two attributes, `name` (`string` type) and `release_date` (`DateTime` type), your POCO class would be created as follows:
 
 ```csharp
 public class TestModel
 {
-  [JsonProperty("name")]
+  [JsonPropertyName("name")]
   public string Name { get; set; }
 
-  [JsonProperty("release_date")]
+  [JsonPropertyName("release_date")]
   public DateTime ReleaseDate { get; set; }
 }
 ```
 
-The `JsonProperty` attribute will ensure that your data object for the Appwrite database is serialized with the correct names.
+The `JsonPropertyName` attribute will ensure that your data object for the Appwrite database is serialized with the correct names.
 
 ## Contribution
 

--- a/docs/examples/databases/upsert-document.md
+++ b/docs/examples/databases/upsert-document.md
@@ -5,12 +5,14 @@ using Appwrite.Services;
 Client client = new Client()
     .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
     .SetProject("<YOUR_PROJECT_ID>") // Your project ID
-    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+    .SetSession(""); // The user session to authenticate with
 
 Databases databases = new Databases(client);
 
-DocumentList result = await databases.UpsertDocuments(
+Document result = await databases.UpsertDocument(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
-    documents: new List<object>()
+    documentId: "<DOCUMENT_ID>",
+    data: [object],
+    permissions: ["read("any")"] // optional
 );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

* Refactor from Newtonsoft.Json to System.Text.Json for serialization/deserialization
* Update package dependencies in `Package.csproj.twig`
* Migrate all serialization/deserialization logic in `Client.cs.twig`, `Query.cs.twig`, and `Extensions.cs.twig`
* Update model attributes from `[JsonProperty]` to `[JsonPropertyName]` in `Model.cs.twig`
* Create new `ObjectToInferredTypesConverter.cs.twig` for proper object type handling
* Replace `JsonConverter` with `JsonConverter<object>` in `ValueClassConverter.cs.twig`
* Update error handling to use `JsonDocument` instead of `JObject`

## Test Plan

## Related PRs and Issues

- https://github.com/appwrite/sdk-generator/pull/1085

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.