### PR TITLE
feat: .NET SDK update for version 3.0.0

### DIFF
--- a/Appwrite/Appwrite.csproj
+++ b/Appwrite/Appwrite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageId>Appwrite</PackageId>
-    <Version>2.0.0</Version>
+    <Version>3.0.0</Version>
     <Authors>Appwrite Team</Authors>
     <Company>Appwrite Team</Company>
     <Description>

--- a/Appwrite/Client.cs
+++ b/Appwrite/Client.cs
@@ -69,12 +69,12 @@ namespace Appwrite
             _headers = new Dictionary<string, string>()
             {
                 { "content-type", "application/json" },
-                { "user-agent" , $"AppwriteDotNetSDK/2.0.0 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
+                { "user-agent" , $"AppwriteDotNetSDK/3.0.0 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
                 { "x-sdk-name", ".NET" },
                 { "x-sdk-platform", "server" },
                 { "x-sdk-language", "dotnet" },
-                { "x-sdk-version", "2.0.0"},
-                { "X-Appwrite-Response-Format", "1.9.0" }
+                { "x-sdk-version", "3.0.0"},
+                { "X-Appwrite-Response-Format", "1.9.1" }
             };
 
             _config = new Dictionary<string, string>();
@@ -185,6 +185,11 @@ namespace Appwrite
             _headers.Add(key, value);
 
             return this;
+        }
+
+        public Dictionary<string, string> GetHeaders()
+        {
+            return new Dictionary<string, string>(_headers);
         }
 
         private HttpRequestMessage PrepareRequest(

--- a/Appwrite/Enums/BuildRuntime.cs
+++ b/Appwrite/Enums/BuildRuntime.cs
@@ -59,6 +59,7 @@ namespace Appwrite.Enums
         public static BuildRuntime Dart38 => new BuildRuntime("dart-3.8");
         public static BuildRuntime Dart39 => new BuildRuntime("dart-3.9");
         public static BuildRuntime Dart310 => new BuildRuntime("dart-3.10");
+        public static BuildRuntime Dart311 => new BuildRuntime("dart-3.11");
         public static BuildRuntime Dotnet60 => new BuildRuntime("dotnet-6.0");
         public static BuildRuntime Dotnet70 => new BuildRuntime("dotnet-7.0");
         public static BuildRuntime Dotnet80 => new BuildRuntime("dotnet-8.0");
@@ -97,5 +98,6 @@ namespace Appwrite.Enums
         public static BuildRuntime Flutter332 => new BuildRuntime("flutter-3.32");
         public static BuildRuntime Flutter335 => new BuildRuntime("flutter-3.35");
         public static BuildRuntime Flutter338 => new BuildRuntime("flutter-3.38");
+        public static BuildRuntime Flutter341 => new BuildRuntime("flutter-3.41");
     }
 }

--- a/Appwrite/Enums/OAuthProvider.cs
+++ b/Appwrite/Enums/OAuthProvider.cs
@@ -45,6 +45,7 @@ namespace Appwrite.Enums
         public static OAuthProvider TradeshiftBox => new OAuthProvider("tradeshiftBox");
         public static OAuthProvider Twitch => new OAuthProvider("twitch");
         public static OAuthProvider Wordpress => new OAuthProvider("wordpress");
+        public static OAuthProvider X => new OAuthProvider("x");
         public static OAuthProvider Yahoo => new OAuthProvider("yahoo");
         public static OAuthProvider Yammer => new OAuthProvider("yammer");
         public static OAuthProvider Yandex => new OAuthProvider("yandex");

--- a/Appwrite/Enums/PlatformType.cs
+++ b/Appwrite/Enums/PlatformType.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Appwrite.Enums
+{
+    public class PlatformType : IEnum
+    {
+        public string Value { get; private set; }
+
+        public PlatformType(string value)
+        {
+            Value = value;
+        }
+
+        public static PlatformType Windows => new PlatformType("windows");
+        public static PlatformType Apple => new PlatformType("apple");
+        public static PlatformType Android => new PlatformType("android");
+        public static PlatformType Linux => new PlatformType("linux");
+        public static PlatformType Web => new PlatformType("web");
+    }
+}

--- a/Appwrite/Enums/ProtocolId.cs
+++ b/Appwrite/Enums/ProtocolId.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Appwrite.Enums
+{
+    public class ProtocolId : IEnum
+    {
+        public string Value { get; private set; }
+
+        public ProtocolId(string value)
+        {
+            Value = value;
+        }
+
+        public static ProtocolId Rest => new ProtocolId("rest");
+        public static ProtocolId Graphql => new ProtocolId("graphql");
+        public static ProtocolId Websocket => new ProtocolId("websocket");
+    }
+}

--- a/Appwrite/Enums/Runtime.cs
+++ b/Appwrite/Enums/Runtime.cs
@@ -59,6 +59,7 @@ namespace Appwrite.Enums
         public static Runtime Dart38 => new Runtime("dart-3.8");
         public static Runtime Dart39 => new Runtime("dart-3.9");
         public static Runtime Dart310 => new Runtime("dart-3.10");
+        public static Runtime Dart311 => new Runtime("dart-3.11");
         public static Runtime Dotnet60 => new Runtime("dotnet-6.0");
         public static Runtime Dotnet70 => new Runtime("dotnet-7.0");
         public static Runtime Dotnet80 => new Runtime("dotnet-8.0");
@@ -97,5 +98,6 @@ namespace Appwrite.Enums
         public static Runtime Flutter332 => new Runtime("flutter-3.32");
         public static Runtime Flutter335 => new Runtime("flutter-3.35");
         public static Runtime Flutter338 => new Runtime("flutter-3.38");
+        public static Runtime Flutter341 => new Runtime("flutter-3.41");
     }
 }

--- a/Appwrite/Enums/Scopes.cs
+++ b/Appwrite/Enums/Scopes.cs
@@ -72,6 +72,10 @@ namespace Appwrite.Enums
         public static Scopes WebhooksWrite => new Scopes("webhooks.write");
         public static Scopes ProjectRead => new Scopes("project.read");
         public static Scopes ProjectWrite => new Scopes("project.write");
+        public static Scopes KeysRead => new Scopes("keys.read");
+        public static Scopes KeysWrite => new Scopes("keys.write");
+        public static Scopes PlatformsRead => new Scopes("platforms.read");
+        public static Scopes PlatformsWrite => new Scopes("platforms.write");
         public static Scopes PoliciesWrite => new Scopes("policies.write");
         public static Scopes PoliciesRead => new Scopes("policies.read");
         public static Scopes ArchivesRead => new Scopes("archives.read");

--- a/Appwrite/Enums/ServiceId.cs
+++ b/Appwrite/Enums/ServiceId.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Appwrite.Enums
+{
+    public class ServiceId : IEnum
+    {
+        public string Value { get; private set; }
+
+        public ServiceId(string value)
+        {
+            Value = value;
+        }
+
+        public static ServiceId Account => new ServiceId("account");
+        public static ServiceId Avatars => new ServiceId("avatars");
+        public static ServiceId Databases => new ServiceId("databases");
+        public static ServiceId Tablesdb => new ServiceId("tablesdb");
+        public static ServiceId Locale => new ServiceId("locale");
+        public static ServiceId Health => new ServiceId("health");
+        public static ServiceId Project => new ServiceId("project");
+        public static ServiceId Storage => new ServiceId("storage");
+        public static ServiceId Teams => new ServiceId("teams");
+        public static ServiceId Users => new ServiceId("users");
+        public static ServiceId Vcs => new ServiceId("vcs");
+        public static ServiceId Sites => new ServiceId("sites");
+        public static ServiceId Functions => new ServiceId("functions");
+        public static ServiceId Proxy => new ServiceId("proxy");
+        public static ServiceId Graphql => new ServiceId("graphql");
+        public static ServiceId Migrations => new ServiceId("migrations");
+        public static ServiceId Messaging => new ServiceId("messaging");
+    }
+}

--- a/Appwrite/Models/AuthProvider.cs
+++ b/Appwrite/Models/AuthProvider.cs
@@ -1,0 +1,60 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class AuthProvider
+    {
+        [JsonPropertyName("key")]
+        public string Key { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("appId")]
+        public string AppId { get; private set; }
+
+        [JsonPropertyName("secret")]
+        public string Secret { get; private set; }
+
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; private set; }
+
+        public AuthProvider(
+            string key,
+            string name,
+            string appId,
+            string secret,
+            bool enabled
+        ) {
+            Key = key;
+            Name = name;
+            AppId = appId;
+            Secret = secret;
+            Enabled = enabled;
+        }
+
+        public static AuthProvider From(Dictionary<string, object> map) => new AuthProvider(
+            key: map["key"].ToString(),
+            name: map["name"].ToString(),
+            appId: map["appId"].ToString(),
+            secret: map["secret"].ToString(),
+            enabled: (bool)map["enabled"]
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "key", Key },
+            { "name", Name },
+            { "appId", AppId },
+            { "secret", Secret },
+            { "enabled", Enabled }
+        };
+    }
+}

--- a/Appwrite/Models/BillingLimits.cs
+++ b/Appwrite/Models/BillingLimits.cs
@@ -1,0 +1,81 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class BillingLimits
+    {
+        [JsonPropertyName("bandwidth")]
+        public long Bandwidth { get; private set; }
+
+        [JsonPropertyName("storage")]
+        public long Storage { get; private set; }
+
+        [JsonPropertyName("users")]
+        public long Users { get; private set; }
+
+        [JsonPropertyName("executions")]
+        public long Executions { get; private set; }
+
+        [JsonPropertyName("GBHours")]
+        public long GBHours { get; private set; }
+
+        [JsonPropertyName("imageTransformations")]
+        public long ImageTransformations { get; private set; }
+
+        [JsonPropertyName("authPhone")]
+        public long AuthPhone { get; private set; }
+
+        [JsonPropertyName("budgetLimit")]
+        public long BudgetLimit { get; private set; }
+
+        public BillingLimits(
+            long bandwidth,
+            long storage,
+            long users,
+            long executions,
+            long gBHours,
+            long imageTransformations,
+            long authPhone,
+            long budgetLimit
+        ) {
+            Bandwidth = bandwidth;
+            Storage = storage;
+            Users = users;
+            Executions = executions;
+            GBHours = gBHours;
+            ImageTransformations = imageTransformations;
+            AuthPhone = authPhone;
+            BudgetLimit = budgetLimit;
+        }
+
+        public static BillingLimits From(Dictionary<string, object> map) => new BillingLimits(
+            bandwidth: Convert.ToInt64(map["bandwidth"]),
+            storage: Convert.ToInt64(map["storage"]),
+            users: Convert.ToInt64(map["users"]),
+            executions: Convert.ToInt64(map["executions"]),
+            gBHours: Convert.ToInt64(map["GBHours"]),
+            imageTransformations: Convert.ToInt64(map["imageTransformations"]),
+            authPhone: Convert.ToInt64(map["authPhone"]),
+            budgetLimit: Convert.ToInt64(map["budgetLimit"])
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "bandwidth", Bandwidth },
+            { "storage", Storage },
+            { "users", Users },
+            { "executions", Executions },
+            { "GBHours", GBHours },
+            { "imageTransformations", ImageTransformations },
+            { "authPhone", AuthPhone },
+            { "budgetLimit", BudgetLimit }
+        };
+    }
+}

--- a/Appwrite/Models/Block.cs
+++ b/Appwrite/Models/Block.cs
@@ -1,0 +1,60 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class Block
+    {
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("resourceType")]
+        public string ResourceType { get; private set; }
+
+        [JsonPropertyName("resourceId")]
+        public string ResourceId { get; private set; }
+
+        [JsonPropertyName("reason")]
+        public string? Reason { get; private set; }
+
+        [JsonPropertyName("expiredAt")]
+        public string? ExpiredAt { get; private set; }
+
+        public Block(
+            string createdAt,
+            string resourceType,
+            string resourceId,
+            string? reason,
+            string? expiredAt
+        ) {
+            CreatedAt = createdAt;
+            ResourceType = resourceType;
+            ResourceId = resourceId;
+            Reason = reason;
+            ExpiredAt = expiredAt;
+        }
+
+        public static Block From(Dictionary<string, object> map) => new Block(
+            createdAt: map["$createdAt"].ToString(),
+            resourceType: map["resourceType"].ToString(),
+            resourceId: map["resourceId"].ToString(),
+            reason: map.TryGetValue("reason", out var reason) ? reason?.ToString() : null,
+            expiredAt: map.TryGetValue("expiredAt", out var expiredAt) ? expiredAt?.ToString() : null
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$createdAt", CreatedAt },
+            { "resourceType", ResourceType },
+            { "resourceId", ResourceId },
+            { "reason", Reason },
+            { "expiredAt", ExpiredAt }
+        };
+    }
+}

--- a/Appwrite/Models/DevKey.cs
+++ b/Appwrite/Models/DevKey.cs
@@ -1,0 +1,81 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class DevKey
+    {
+        [JsonPropertyName("$id")]
+        public string Id { get; private set; }
+
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("$updatedAt")]
+        public string UpdatedAt { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("expire")]
+        public string Expire { get; private set; }
+
+        [JsonPropertyName("secret")]
+        public string Secret { get; private set; }
+
+        [JsonPropertyName("accessedAt")]
+        public string AccessedAt { get; private set; }
+
+        [JsonPropertyName("sdks")]
+        public List<string> Sdks { get; private set; }
+
+        public DevKey(
+            string id,
+            string createdAt,
+            string updatedAt,
+            string name,
+            string expire,
+            string secret,
+            string accessedAt,
+            List<string> sdks
+        ) {
+            Id = id;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Name = name;
+            Expire = expire;
+            Secret = secret;
+            AccessedAt = accessedAt;
+            Sdks = sdks;
+        }
+
+        public static DevKey From(Dictionary<string, object> map) => new DevKey(
+            id: map["$id"].ToString(),
+            createdAt: map["$createdAt"].ToString(),
+            updatedAt: map["$updatedAt"].ToString(),
+            name: map["name"].ToString(),
+            expire: map["expire"].ToString(),
+            secret: map["secret"].ToString(),
+            accessedAt: map["accessedAt"].ToString(),
+            sdks: map["sdks"].ConvertToList<string>()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$id", Id },
+            { "$createdAt", CreatedAt },
+            { "$updatedAt", UpdatedAt },
+            { "name", Name },
+            { "expire", Expire },
+            { "secret", Secret },
+            { "accessedAt", AccessedAt },
+            { "sdks", Sdks }
+        };
+    }
+}

--- a/Appwrite/Models/Key.cs
+++ b/Appwrite/Models/Key.cs
@@ -1,0 +1,88 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class Key
+    {
+        [JsonPropertyName("$id")]
+        public string Id { get; private set; }
+
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("$updatedAt")]
+        public string UpdatedAt { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("expire")]
+        public string Expire { get; private set; }
+
+        [JsonPropertyName("scopes")]
+        public List<string> Scopes { get; private set; }
+
+        [JsonPropertyName("secret")]
+        public string Secret { get; private set; }
+
+        [JsonPropertyName("accessedAt")]
+        public string AccessedAt { get; private set; }
+
+        [JsonPropertyName("sdks")]
+        public List<string> Sdks { get; private set; }
+
+        public Key(
+            string id,
+            string createdAt,
+            string updatedAt,
+            string name,
+            string expire,
+            List<string> scopes,
+            string secret,
+            string accessedAt,
+            List<string> sdks
+        ) {
+            Id = id;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Name = name;
+            Expire = expire;
+            Scopes = scopes;
+            Secret = secret;
+            AccessedAt = accessedAt;
+            Sdks = sdks;
+        }
+
+        public static Key From(Dictionary<string, object> map) => new Key(
+            id: map["$id"].ToString(),
+            createdAt: map["$createdAt"].ToString(),
+            updatedAt: map["$updatedAt"].ToString(),
+            name: map["name"].ToString(),
+            expire: map["expire"].ToString(),
+            scopes: map["scopes"].ConvertToList<string>(),
+            secret: map["secret"].ToString(),
+            accessedAt: map["accessedAt"].ToString(),
+            sdks: map["sdks"].ConvertToList<string>()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$id", Id },
+            { "$createdAt", CreatedAt },
+            { "$updatedAt", UpdatedAt },
+            { "name", Name },
+            { "expire", Expire },
+            { "scopes", Scopes },
+            { "secret", Secret },
+            { "accessedAt", AccessedAt },
+            { "sdks", Sdks }
+        };
+    }
+}

--- a/Appwrite/Models/KeyList.cs
+++ b/Appwrite/Models/KeyList.cs
@@ -1,0 +1,39 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class KeyList
+    {
+        [JsonPropertyName("total")]
+        public long Total { get; private set; }
+
+        [JsonPropertyName("keys")]
+        public List<Key> Keys { get; private set; }
+
+        public KeyList(
+            long total,
+            List<Key> keys
+        ) {
+            Total = total;
+            Keys = keys;
+        }
+
+        public static KeyList From(Dictionary<string, object> map) => new KeyList(
+            total: Convert.ToInt64(map["total"]),
+            keys: map["keys"].ConvertToList<Dictionary<string, object>>().Select(it => Key.From(map: it)).ToList()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "total", Total },
+            { "keys", Keys.Select(it => it.ToMap()) }
+        };
+    }
+}

--- a/Appwrite/Models/Log.cs
+++ b/Appwrite/Models/Log.cs
@@ -26,6 +26,9 @@ namespace Appwrite.Models
         [JsonPropertyName("mode")]
         public string Mode { get; private set; }
 
+        [JsonPropertyName("userType")]
+        public string UserType { get; private set; }
+
         [JsonPropertyName("ip")]
         public string Ip { get; private set; }
 
@@ -80,6 +83,7 @@ namespace Appwrite.Models
             string userEmail,
             string userName,
             string mode,
+            string userType,
             string ip,
             string time,
             string osCode,
@@ -102,6 +106,7 @@ namespace Appwrite.Models
             UserEmail = userEmail;
             UserName = userName;
             Mode = mode;
+            UserType = userType;
             Ip = ip;
             Time = time;
             OsCode = osCode;
@@ -126,6 +131,7 @@ namespace Appwrite.Models
             userEmail: map["userEmail"].ToString(),
             userName: map["userName"].ToString(),
             mode: map["mode"].ToString(),
+            userType: map["userType"].ToString(),
             ip: map["ip"].ToString(),
             time: map["time"].ToString(),
             osCode: map["osCode"].ToString(),
@@ -151,6 +157,7 @@ namespace Appwrite.Models
             { "userEmail", UserEmail },
             { "userName", UserName },
             { "mode", Mode },
+            { "userType", UserType },
             { "ip", Ip },
             { "time", Time },
             { "osCode", OsCode },

--- a/Appwrite/Models/MockNumber.cs
+++ b/Appwrite/Models/MockNumber.cs
@@ -1,0 +1,39 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class MockNumber
+    {
+        [JsonPropertyName("phone")]
+        public string Phone { get; private set; }
+
+        [JsonPropertyName("otp")]
+        public string Otp { get; private set; }
+
+        public MockNumber(
+            string phone,
+            string otp
+        ) {
+            Phone = phone;
+            Otp = otp;
+        }
+
+        public static MockNumber From(Dictionary<string, object> map) => new MockNumber(
+            phone: map["phone"].ToString(),
+            otp: map["otp"].ToString()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "phone", Phone },
+            { "otp", Otp }
+        };
+    }
+}

--- a/Appwrite/Models/PlatformAndroid.cs
+++ b/Appwrite/Models/PlatformAndroid.cs
@@ -1,0 +1,67 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class PlatformAndroid
+    {
+        [JsonPropertyName("$id")]
+        public string Id { get; private set; }
+
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("$updatedAt")]
+        public string UpdatedAt { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("type")]
+        public PlatformType Type { get; private set; }
+
+        [JsonPropertyName("applicationId")]
+        public string ApplicationId { get; private set; }
+
+        public PlatformAndroid(
+            string id,
+            string createdAt,
+            string updatedAt,
+            string name,
+            PlatformType type,
+            string applicationId
+        ) {
+            Id = id;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Name = name;
+            Type = type;
+            ApplicationId = applicationId;
+        }
+
+        public static PlatformAndroid From(Dictionary<string, object> map) => new PlatformAndroid(
+            id: map["$id"].ToString(),
+            createdAt: map["$createdAt"].ToString(),
+            updatedAt: map["$updatedAt"].ToString(),
+            name: map["name"].ToString(),
+            type: new PlatformType(map["type"].ToString()!),
+            applicationId: map["applicationId"].ToString()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$id", Id },
+            { "$createdAt", CreatedAt },
+            { "$updatedAt", UpdatedAt },
+            { "name", Name },
+            { "type", Type.Value },
+            { "applicationId", ApplicationId }
+        };
+    }
+}

--- a/Appwrite/Models/PlatformApple.cs
+++ b/Appwrite/Models/PlatformApple.cs
@@ -1,0 +1,67 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class PlatformApple
+    {
+        [JsonPropertyName("$id")]
+        public string Id { get; private set; }
+
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("$updatedAt")]
+        public string UpdatedAt { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("type")]
+        public PlatformType Type { get; private set; }
+
+        [JsonPropertyName("bundleIdentifier")]
+        public string BundleIdentifier { get; private set; }
+
+        public PlatformApple(
+            string id,
+            string createdAt,
+            string updatedAt,
+            string name,
+            PlatformType type,
+            string bundleIdentifier
+        ) {
+            Id = id;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Name = name;
+            Type = type;
+            BundleIdentifier = bundleIdentifier;
+        }
+
+        public static PlatformApple From(Dictionary<string, object> map) => new PlatformApple(
+            id: map["$id"].ToString(),
+            createdAt: map["$createdAt"].ToString(),
+            updatedAt: map["$updatedAt"].ToString(),
+            name: map["name"].ToString(),
+            type: new PlatformType(map["type"].ToString()!),
+            bundleIdentifier: map["bundleIdentifier"].ToString()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$id", Id },
+            { "$createdAt", CreatedAt },
+            { "$updatedAt", UpdatedAt },
+            { "name", Name },
+            { "type", Type.Value },
+            { "bundleIdentifier", BundleIdentifier }
+        };
+    }
+}

--- a/Appwrite/Models/PlatformLinux.cs
+++ b/Appwrite/Models/PlatformLinux.cs
@@ -1,0 +1,67 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class PlatformLinux
+    {
+        [JsonPropertyName("$id")]
+        public string Id { get; private set; }
+
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("$updatedAt")]
+        public string UpdatedAt { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("type")]
+        public PlatformType Type { get; private set; }
+
+        [JsonPropertyName("packageName")]
+        public string PackageName { get; private set; }
+
+        public PlatformLinux(
+            string id,
+            string createdAt,
+            string updatedAt,
+            string name,
+            PlatformType type,
+            string packageName
+        ) {
+            Id = id;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Name = name;
+            Type = type;
+            PackageName = packageName;
+        }
+
+        public static PlatformLinux From(Dictionary<string, object> map) => new PlatformLinux(
+            id: map["$id"].ToString(),
+            createdAt: map["$createdAt"].ToString(),
+            updatedAt: map["$updatedAt"].ToString(),
+            name: map["name"].ToString(),
+            type: new PlatformType(map["type"].ToString()!),
+            packageName: map["packageName"].ToString()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$id", Id },
+            { "$createdAt", CreatedAt },
+            { "$updatedAt", UpdatedAt },
+            { "name", Name },
+            { "type", Type.Value },
+            { "packageName", PackageName }
+        };
+    }
+}

--- a/Appwrite/Models/PlatformList.cs
+++ b/Appwrite/Models/PlatformList.cs
@@ -1,0 +1,39 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class PlatformList
+    {
+        [JsonPropertyName("total")]
+        public long Total { get; private set; }
+
+        [JsonPropertyName("platforms")]
+        public List<object> Platforms { get; private set; }
+
+        public PlatformList(
+            long total,
+            List<object> platforms
+        ) {
+            Total = total;
+            Platforms = platforms;
+        }
+
+        public static PlatformList From(Dictionary<string, object> map) => new PlatformList(
+            total: Convert.ToInt64(map["total"]),
+            platforms: map["platforms"].ConvertToList<object>()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "total", Total },
+            { "platforms", Platforms }
+        };
+    }
+}

--- a/Appwrite/Models/PlatformWeb.cs
+++ b/Appwrite/Models/PlatformWeb.cs
@@ -1,0 +1,67 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class PlatformWeb
+    {
+        [JsonPropertyName("$id")]
+        public string Id { get; private set; }
+
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("$updatedAt")]
+        public string UpdatedAt { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("type")]
+        public PlatformType Type { get; private set; }
+
+        [JsonPropertyName("hostname")]
+        public string Hostname { get; private set; }
+
+        public PlatformWeb(
+            string id,
+            string createdAt,
+            string updatedAt,
+            string name,
+            PlatformType type,
+            string hostname
+        ) {
+            Id = id;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Name = name;
+            Type = type;
+            Hostname = hostname;
+        }
+
+        public static PlatformWeb From(Dictionary<string, object> map) => new PlatformWeb(
+            id: map["$id"].ToString(),
+            createdAt: map["$createdAt"].ToString(),
+            updatedAt: map["$updatedAt"].ToString(),
+            name: map["name"].ToString(),
+            type: new PlatformType(map["type"].ToString()!),
+            hostname: map["hostname"].ToString()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$id", Id },
+            { "$createdAt", CreatedAt },
+            { "$updatedAt", UpdatedAt },
+            { "name", Name },
+            { "type", Type.Value },
+            { "hostname", Hostname }
+        };
+    }
+}

--- a/Appwrite/Models/PlatformWindows.cs
+++ b/Appwrite/Models/PlatformWindows.cs
@@ -1,0 +1,67 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class PlatformWindows
+    {
+        [JsonPropertyName("$id")]
+        public string Id { get; private set; }
+
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("$updatedAt")]
+        public string UpdatedAt { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("type")]
+        public PlatformType Type { get; private set; }
+
+        [JsonPropertyName("packageIdentifierName")]
+        public string PackageIdentifierName { get; private set; }
+
+        public PlatformWindows(
+            string id,
+            string createdAt,
+            string updatedAt,
+            string name,
+            PlatformType type,
+            string packageIdentifierName
+        ) {
+            Id = id;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Name = name;
+            Type = type;
+            PackageIdentifierName = packageIdentifierName;
+        }
+
+        public static PlatformWindows From(Dictionary<string, object> map) => new PlatformWindows(
+            id: map["$id"].ToString(),
+            createdAt: map["$createdAt"].ToString(),
+            updatedAt: map["$updatedAt"].ToString(),
+            name: map["name"].ToString(),
+            type: new PlatformType(map["type"].ToString()!),
+            packageIdentifierName: map["packageIdentifierName"].ToString()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$id", Id },
+            { "$createdAt", CreatedAt },
+            { "$updatedAt", UpdatedAt },
+            { "name", Name },
+            { "type", Type.Value },
+            { "packageIdentifierName", PackageIdentifierName }
+        };
+    }
+}

--- a/Appwrite/Models/Project.cs
+++ b/Appwrite/Models/Project.cs
@@ -1,0 +1,571 @@
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Appwrite.Enums;
+using Appwrite.Extensions;
+
+namespace Appwrite.Models
+{
+    public class Project
+    {
+        [JsonPropertyName("$id")]
+        public string Id { get; private set; }
+
+        [JsonPropertyName("$createdAt")]
+        public string CreatedAt { get; private set; }
+
+        [JsonPropertyName("$updatedAt")]
+        public string UpdatedAt { get; private set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; private set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; private set; }
+
+        [JsonPropertyName("teamId")]
+        public string TeamId { get; private set; }
+
+        [JsonPropertyName("logo")]
+        public string Logo { get; private set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; private set; }
+
+        [JsonPropertyName("legalName")]
+        public string LegalName { get; private set; }
+
+        [JsonPropertyName("legalCountry")]
+        public string LegalCountry { get; private set; }
+
+        [JsonPropertyName("legalState")]
+        public string LegalState { get; private set; }
+
+        [JsonPropertyName("legalCity")]
+        public string LegalCity { get; private set; }
+
+        [JsonPropertyName("legalAddress")]
+        public string LegalAddress { get; private set; }
+
+        [JsonPropertyName("legalTaxId")]
+        public string LegalTaxId { get; private set; }
+
+        [JsonPropertyName("authDuration")]
+        public long AuthDuration { get; private set; }
+
+        [JsonPropertyName("authLimit")]
+        public long AuthLimit { get; private set; }
+
+        [JsonPropertyName("authSessionsLimit")]
+        public long AuthSessionsLimit { get; private set; }
+
+        [JsonPropertyName("authPasswordHistory")]
+        public long AuthPasswordHistory { get; private set; }
+
+        [JsonPropertyName("authPasswordDictionary")]
+        public bool AuthPasswordDictionary { get; private set; }
+
+        [JsonPropertyName("authPersonalDataCheck")]
+        public bool AuthPersonalDataCheck { get; private set; }
+
+        [JsonPropertyName("authDisposableEmails")]
+        public bool AuthDisposableEmails { get; private set; }
+
+        [JsonPropertyName("authCanonicalEmails")]
+        public bool AuthCanonicalEmails { get; private set; }
+
+        [JsonPropertyName("authFreeEmails")]
+        public bool AuthFreeEmails { get; private set; }
+
+        [JsonPropertyName("authMockNumbers")]
+        public List<MockNumber> AuthMockNumbers { get; private set; }
+
+        [JsonPropertyName("authSessionAlerts")]
+        public bool AuthSessionAlerts { get; private set; }
+
+        [JsonPropertyName("authMembershipsUserName")]
+        public bool AuthMembershipsUserName { get; private set; }
+
+        [JsonPropertyName("authMembershipsUserEmail")]
+        public bool AuthMembershipsUserEmail { get; private set; }
+
+        [JsonPropertyName("authMembershipsMfa")]
+        public bool AuthMembershipsMfa { get; private set; }
+
+        [JsonPropertyName("authInvalidateSessions")]
+        public bool AuthInvalidateSessions { get; private set; }
+
+        [JsonPropertyName("oAuthProviders")]
+        public List<AuthProvider> OAuthProviders { get; private set; }
+
+        [JsonPropertyName("platforms")]
+        public List<object> Platforms { get; private set; }
+
+        [JsonPropertyName("webhooks")]
+        public List<Webhook> Webhooks { get; private set; }
+
+        [JsonPropertyName("keys")]
+        public List<Key> Keys { get; private set; }
+
+        [JsonPropertyName("devKeys")]
+        public List<DevKey> DevKeys { get; private set; }
+
+        [JsonPropertyName("smtpEnabled")]
+        public bool SmtpEnabled { get; private set; }
+
+        [JsonPropertyName("smtpSenderName")]
+        public string SmtpSenderName { get; private set; }
+
+        [JsonPropertyName("smtpSenderEmail")]
+        public string SmtpSenderEmail { get; private set; }
+
+        [JsonPropertyName("smtpReplyTo")]
+        public string SmtpReplyTo { get; private set; }
+
+        [JsonPropertyName("smtpHost")]
+        public string SmtpHost { get; private set; }
+
+        [JsonPropertyName("smtpPort")]
+        public long SmtpPort { get; private set; }
+
+        [JsonPropertyName("smtpUsername")]
+        public string SmtpUsername { get; private set; }
+
+        [JsonPropertyName("smtpPassword")]
+        public string SmtpPassword { get; private set; }
+
+        [JsonPropertyName("smtpSecure")]
+        public string SmtpSecure { get; private set; }
+
+        [JsonPropertyName("pingCount")]
+        public long PingCount { get; private set; }
+
+        [JsonPropertyName("pingedAt")]
+        public string PingedAt { get; private set; }
+
+        [JsonPropertyName("labels")]
+        public List<string> Labels { get; private set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; private set; }
+
+        [JsonPropertyName("authEmailPassword")]
+        public bool AuthEmailPassword { get; private set; }
+
+        [JsonPropertyName("authUsersAuthMagicURL")]
+        public bool AuthUsersAuthMagicURL { get; private set; }
+
+        [JsonPropertyName("authEmailOtp")]
+        public bool AuthEmailOtp { get; private set; }
+
+        [JsonPropertyName("authAnonymous")]
+        public bool AuthAnonymous { get; private set; }
+
+        [JsonPropertyName("authInvites")]
+        public bool AuthInvites { get; private set; }
+
+        [JsonPropertyName("authJWT")]
+        public bool AuthJWT { get; private set; }
+
+        [JsonPropertyName("authPhone")]
+        public bool AuthPhone { get; private set; }
+
+        [JsonPropertyName("serviceStatusForAccount")]
+        public bool ServiceStatusForAccount { get; private set; }
+
+        [JsonPropertyName("serviceStatusForAvatars")]
+        public bool ServiceStatusForAvatars { get; private set; }
+
+        [JsonPropertyName("serviceStatusForDatabases")]
+        public bool ServiceStatusForDatabases { get; private set; }
+
+        [JsonPropertyName("serviceStatusForTablesdb")]
+        public bool ServiceStatusForTablesdb { get; private set; }
+
+        [JsonPropertyName("serviceStatusForLocale")]
+        public bool ServiceStatusForLocale { get; private set; }
+
+        [JsonPropertyName("serviceStatusForHealth")]
+        public bool ServiceStatusForHealth { get; private set; }
+
+        [JsonPropertyName("serviceStatusForProject")]
+        public bool ServiceStatusForProject { get; private set; }
+
+        [JsonPropertyName("serviceStatusForStorage")]
+        public bool ServiceStatusForStorage { get; private set; }
+
+        [JsonPropertyName("serviceStatusForTeams")]
+        public bool ServiceStatusForTeams { get; private set; }
+
+        [JsonPropertyName("serviceStatusForUsers")]
+        public bool ServiceStatusForUsers { get; private set; }
+
+        [JsonPropertyName("serviceStatusForVcs")]
+        public bool ServiceStatusForVcs { get; private set; }
+
+        [JsonPropertyName("serviceStatusForSites")]
+        public bool ServiceStatusForSites { get; private set; }
+
+        [JsonPropertyName("serviceStatusForFunctions")]
+        public bool ServiceStatusForFunctions { get; private set; }
+
+        [JsonPropertyName("serviceStatusForProxy")]
+        public bool ServiceStatusForProxy { get; private set; }
+
+        [JsonPropertyName("serviceStatusForGraphql")]
+        public bool ServiceStatusForGraphql { get; private set; }
+
+        [JsonPropertyName("serviceStatusForMigrations")]
+        public bool ServiceStatusForMigrations { get; private set; }
+
+        [JsonPropertyName("serviceStatusForMessaging")]
+        public bool ServiceStatusForMessaging { get; private set; }
+
+        [JsonPropertyName("protocolStatusForRest")]
+        public bool ProtocolStatusForRest { get; private set; }
+
+        [JsonPropertyName("protocolStatusForGraphql")]
+        public bool ProtocolStatusForGraphql { get; private set; }
+
+        [JsonPropertyName("protocolStatusForWebsocket")]
+        public bool ProtocolStatusForWebsocket { get; private set; }
+
+        [JsonPropertyName("region")]
+        public string Region { get; private set; }
+
+        [JsonPropertyName("billingLimits")]
+        public BillingLimits BillingLimits { get; private set; }
+
+        [JsonPropertyName("blocks")]
+        public List<Block> Blocks { get; private set; }
+
+        [JsonPropertyName("consoleAccessedAt")]
+        public string ConsoleAccessedAt { get; private set; }
+
+        public Project(
+            string id,
+            string createdAt,
+            string updatedAt,
+            string name,
+            string description,
+            string teamId,
+            string logo,
+            string url,
+            string legalName,
+            string legalCountry,
+            string legalState,
+            string legalCity,
+            string legalAddress,
+            string legalTaxId,
+            long authDuration,
+            long authLimit,
+            long authSessionsLimit,
+            long authPasswordHistory,
+            bool authPasswordDictionary,
+            bool authPersonalDataCheck,
+            bool authDisposableEmails,
+            bool authCanonicalEmails,
+            bool authFreeEmails,
+            List<MockNumber> authMockNumbers,
+            bool authSessionAlerts,
+            bool authMembershipsUserName,
+            bool authMembershipsUserEmail,
+            bool authMembershipsMfa,
+            bool authInvalidateSessions,
+            List<AuthProvider> oAuthProviders,
+            List<object> platforms,
+            List<Webhook> webhooks,
+            List<Key> keys,
+            List<DevKey> devKeys,
+            bool smtpEnabled,
+            string smtpSenderName,
+            string smtpSenderEmail,
+            string smtpReplyTo,
+            string smtpHost,
+            long smtpPort,
+            string smtpUsername,
+            string smtpPassword,
+            string smtpSecure,
+            long pingCount,
+            string pingedAt,
+            List<string> labels,
+            string status,
+            bool authEmailPassword,
+            bool authUsersAuthMagicURL,
+            bool authEmailOtp,
+            bool authAnonymous,
+            bool authInvites,
+            bool authJWT,
+            bool authPhone,
+            bool serviceStatusForAccount,
+            bool serviceStatusForAvatars,
+            bool serviceStatusForDatabases,
+            bool serviceStatusForTablesdb,
+            bool serviceStatusForLocale,
+            bool serviceStatusForHealth,
+            bool serviceStatusForProject,
+            bool serviceStatusForStorage,
+            bool serviceStatusForTeams,
+            bool serviceStatusForUsers,
+            bool serviceStatusForVcs,
+            bool serviceStatusForSites,
+            bool serviceStatusForFunctions,
+            bool serviceStatusForProxy,
+            bool serviceStatusForGraphql,
+            bool serviceStatusForMigrations,
+            bool serviceStatusForMessaging,
+            bool protocolStatusForRest,
+            bool protocolStatusForGraphql,
+            bool protocolStatusForWebsocket,
+            string region,
+            BillingLimits billingLimits,
+            List<Block> blocks,
+            string consoleAccessedAt
+        ) {
+            Id = id;
+            CreatedAt = createdAt;
+            UpdatedAt = updatedAt;
+            Name = name;
+            Description = description;
+            TeamId = teamId;
+            Logo = logo;
+            Url = url;
+            LegalName = legalName;
+            LegalCountry = legalCountry;
+            LegalState = legalState;
+            LegalCity = legalCity;
+            LegalAddress = legalAddress;
+            LegalTaxId = legalTaxId;
+            AuthDuration = authDuration;
+            AuthLimit = authLimit;
+            AuthSessionsLimit = authSessionsLimit;
+            AuthPasswordHistory = authPasswordHistory;
+            AuthPasswordDictionary = authPasswordDictionary;
+            AuthPersonalDataCheck = authPersonalDataCheck;
+            AuthDisposableEmails = authDisposableEmails;
+            AuthCanonicalEmails = authCanonicalEmails;
+            AuthFreeEmails = authFreeEmails;
+            AuthMockNumbers = authMockNumbers;
+            AuthSessionAlerts = authSessionAlerts;
+            AuthMembershipsUserName = authMembershipsUserName;
+            AuthMembershipsUserEmail = authMembershipsUserEmail;
+            AuthMembershipsMfa = authMembershipsMfa;
+            AuthInvalidateSessions = authInvalidateSessions;
+            OAuthProviders = oAuthProviders;
+            Platforms = platforms;
+            Webhooks = webhooks;
+            Keys = keys;
+            DevKeys = devKeys;
+            SmtpEnabled = smtpEnabled;
+            SmtpSenderName = smtpSenderName;
+            SmtpSenderEmail = smtpSenderEmail;
+            SmtpReplyTo = smtpReplyTo;
+            SmtpHost = smtpHost;
+            SmtpPort = smtpPort;
+            SmtpUsername = smtpUsername;
+            SmtpPassword = smtpPassword;
+            SmtpSecure = smtpSecure;
+            PingCount = pingCount;
+            PingedAt = pingedAt;
+            Labels = labels;
+            Status = status;
+            AuthEmailPassword = authEmailPassword;
+            AuthUsersAuthMagicURL = authUsersAuthMagicURL;
+            AuthEmailOtp = authEmailOtp;
+            AuthAnonymous = authAnonymous;
+            AuthInvites = authInvites;
+            AuthJWT = authJWT;
+            AuthPhone = authPhone;
+            ServiceStatusForAccount = serviceStatusForAccount;
+            ServiceStatusForAvatars = serviceStatusForAvatars;
+            ServiceStatusForDatabases = serviceStatusForDatabases;
+            ServiceStatusForTablesdb = serviceStatusForTablesdb;
+            ServiceStatusForLocale = serviceStatusForLocale;
+            ServiceStatusForHealth = serviceStatusForHealth;
+            ServiceStatusForProject = serviceStatusForProject;
+            ServiceStatusForStorage = serviceStatusForStorage;
+            ServiceStatusForTeams = serviceStatusForTeams;
+            ServiceStatusForUsers = serviceStatusForUsers;
+            ServiceStatusForVcs = serviceStatusForVcs;
+            ServiceStatusForSites = serviceStatusForSites;
+            ServiceStatusForFunctions = serviceStatusForFunctions;
+            ServiceStatusForProxy = serviceStatusForProxy;
+            ServiceStatusForGraphql = serviceStatusForGraphql;
+            ServiceStatusForMigrations = serviceStatusForMigrations;
+            ServiceStatusForMessaging = serviceStatusForMessaging;
+            ProtocolStatusForRest = protocolStatusForRest;
+            ProtocolStatusForGraphql = protocolStatusForGraphql;
+            ProtocolStatusForWebsocket = protocolStatusForWebsocket;
+            Region = region;
+            BillingLimits = billingLimits;
+            Blocks = blocks;
+            ConsoleAccessedAt = consoleAccessedAt;
+        }
+
+        public static Project From(Dictionary<string, object> map) => new Project(
+            id: map["$id"].ToString(),
+            createdAt: map["$createdAt"].ToString(),
+            updatedAt: map["$updatedAt"].ToString(),
+            name: map["name"].ToString(),
+            description: map["description"].ToString(),
+            teamId: map["teamId"].ToString(),
+            logo: map["logo"].ToString(),
+            url: map["url"].ToString(),
+            legalName: map["legalName"].ToString(),
+            legalCountry: map["legalCountry"].ToString(),
+            legalState: map["legalState"].ToString(),
+            legalCity: map["legalCity"].ToString(),
+            legalAddress: map["legalAddress"].ToString(),
+            legalTaxId: map["legalTaxId"].ToString(),
+            authDuration: Convert.ToInt64(map["authDuration"]),
+            authLimit: Convert.ToInt64(map["authLimit"]),
+            authSessionsLimit: Convert.ToInt64(map["authSessionsLimit"]),
+            authPasswordHistory: Convert.ToInt64(map["authPasswordHistory"]),
+            authPasswordDictionary: (bool)map["authPasswordDictionary"],
+            authPersonalDataCheck: (bool)map["authPersonalDataCheck"],
+            authDisposableEmails: (bool)map["authDisposableEmails"],
+            authCanonicalEmails: (bool)map["authCanonicalEmails"],
+            authFreeEmails: (bool)map["authFreeEmails"],
+            authMockNumbers: map["authMockNumbers"].ConvertToList<Dictionary<string, object>>().Select(it => MockNumber.From(map: it)).ToList(),
+            authSessionAlerts: (bool)map["authSessionAlerts"],
+            authMembershipsUserName: (bool)map["authMembershipsUserName"],
+            authMembershipsUserEmail: (bool)map["authMembershipsUserEmail"],
+            authMembershipsMfa: (bool)map["authMembershipsMfa"],
+            authInvalidateSessions: (bool)map["authInvalidateSessions"],
+            oAuthProviders: map["oAuthProviders"].ConvertToList<Dictionary<string, object>>().Select(it => AuthProvider.From(map: it)).ToList(),
+            platforms: map["platforms"].ConvertToList<object>(),
+            webhooks: map["webhooks"].ConvertToList<Dictionary<string, object>>().Select(it => Webhook.From(map: it)).ToList(),
+            keys: map["keys"].ConvertToList<Dictionary<string, object>>().Select(it => Key.From(map: it)).ToList(),
+            devKeys: map["devKeys"].ConvertToList<Dictionary<string, object>>().Select(it => DevKey.From(map: it)).ToList(),
+            smtpEnabled: (bool)map["smtpEnabled"],
+            smtpSenderName: map["smtpSenderName"].ToString(),
+            smtpSenderEmail: map["smtpSenderEmail"].ToString(),
+            smtpReplyTo: map["smtpReplyTo"].ToString(),
+            smtpHost: map["smtpHost"].ToString(),
+            smtpPort: Convert.ToInt64(map["smtpPort"]),
+            smtpUsername: map["smtpUsername"].ToString(),
+            smtpPassword: map["smtpPassword"].ToString(),
+            smtpSecure: map["smtpSecure"].ToString(),
+            pingCount: Convert.ToInt64(map["pingCount"]),
+            pingedAt: map["pingedAt"].ToString(),
+            labels: map["labels"].ConvertToList<string>(),
+            status: map["status"].ToString(),
+            authEmailPassword: (bool)map["authEmailPassword"],
+            authUsersAuthMagicURL: (bool)map["authUsersAuthMagicURL"],
+            authEmailOtp: (bool)map["authEmailOtp"],
+            authAnonymous: (bool)map["authAnonymous"],
+            authInvites: (bool)map["authInvites"],
+            authJWT: (bool)map["authJWT"],
+            authPhone: (bool)map["authPhone"],
+            serviceStatusForAccount: (bool)map["serviceStatusForAccount"],
+            serviceStatusForAvatars: (bool)map["serviceStatusForAvatars"],
+            serviceStatusForDatabases: (bool)map["serviceStatusForDatabases"],
+            serviceStatusForTablesdb: (bool)map["serviceStatusForTablesdb"],
+            serviceStatusForLocale: (bool)map["serviceStatusForLocale"],
+            serviceStatusForHealth: (bool)map["serviceStatusForHealth"],
+            serviceStatusForProject: (bool)map["serviceStatusForProject"],
+            serviceStatusForStorage: (bool)map["serviceStatusForStorage"],
+            serviceStatusForTeams: (bool)map["serviceStatusForTeams"],
+            serviceStatusForUsers: (bool)map["serviceStatusForUsers"],
+            serviceStatusForVcs: (bool)map["serviceStatusForVcs"],
+            serviceStatusForSites: (bool)map["serviceStatusForSites"],
+            serviceStatusForFunctions: (bool)map["serviceStatusForFunctions"],
+            serviceStatusForProxy: (bool)map["serviceStatusForProxy"],
+            serviceStatusForGraphql: (bool)map["serviceStatusForGraphql"],
+            serviceStatusForMigrations: (bool)map["serviceStatusForMigrations"],
+            serviceStatusForMessaging: (bool)map["serviceStatusForMessaging"],
+            protocolStatusForRest: (bool)map["protocolStatusForRest"],
+            protocolStatusForGraphql: (bool)map["protocolStatusForGraphql"],
+            protocolStatusForWebsocket: (bool)map["protocolStatusForWebsocket"],
+            region: map["region"].ToString(),
+            billingLimits: BillingLimits.From(map: map["billingLimits"] is JsonElement jsonObj76 ? jsonObj76.Deserialize<Dictionary<string, object>>()! : (Dictionary<string, object>)map["billingLimits"]),
+            blocks: map["blocks"].ConvertToList<Dictionary<string, object>>().Select(it => Block.From(map: it)).ToList(),
+            consoleAccessedAt: map["consoleAccessedAt"].ToString()
+        );
+
+        public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()
+        {
+            { "$id", Id },
+            { "$createdAt", CreatedAt },
+            { "$updatedAt", UpdatedAt },
+            { "name", Name },
+            { "description", Description },
+            { "teamId", TeamId },
+            { "logo", Logo },
+            { "url", Url },
+            { "legalName", LegalName },
+            { "legalCountry", LegalCountry },
+            { "legalState", LegalState },
+            { "legalCity", LegalCity },
+            { "legalAddress", LegalAddress },
+            { "legalTaxId", LegalTaxId },
+            { "authDuration", AuthDuration },
+            { "authLimit", AuthLimit },
+            { "authSessionsLimit", AuthSessionsLimit },
+            { "authPasswordHistory", AuthPasswordHistory },
+            { "authPasswordDictionary", AuthPasswordDictionary },
+            { "authPersonalDataCheck", AuthPersonalDataCheck },
+            { "authDisposableEmails", AuthDisposableEmails },
+            { "authCanonicalEmails", AuthCanonicalEmails },
+            { "authFreeEmails", AuthFreeEmails },
+            { "authMockNumbers", AuthMockNumbers.Select(it => it.ToMap()) },
+            { "authSessionAlerts", AuthSessionAlerts },
+            { "authMembershipsUserName", AuthMembershipsUserName },
+            { "authMembershipsUserEmail", AuthMembershipsUserEmail },
+            { "authMembershipsMfa", AuthMembershipsMfa },
+            { "authInvalidateSessions", AuthInvalidateSessions },
+            { "oAuthProviders", OAuthProviders.Select(it => it.ToMap()) },
+            { "platforms", Platforms },
+            { "webhooks", Webhooks.Select(it => it.ToMap()) },
+            { "keys", Keys.Select(it => it.ToMap()) },
+            { "devKeys", DevKeys.Select(it => it.ToMap()) },
+            { "smtpEnabled", SmtpEnabled },
+            { "smtpSenderName", SmtpSenderName },
+            { "smtpSenderEmail", SmtpSenderEmail },
+            { "smtpReplyTo", SmtpReplyTo },
+            { "smtpHost", SmtpHost },
+            { "smtpPort", SmtpPort },
+            { "smtpUsername", SmtpUsername },
+            { "smtpPassword", SmtpPassword },
+            { "smtpSecure", SmtpSecure },
+            { "pingCount", PingCount },
+            { "pingedAt", PingedAt },
+            { "labels", Labels },
+            { "status", Status },
+            { "authEmailPassword", AuthEmailPassword },
+            { "authUsersAuthMagicURL", AuthUsersAuthMagicURL },
+            { "authEmailOtp", AuthEmailOtp },
+            { "authAnonymous", AuthAnonymous },
+            { "authInvites", AuthInvites },
+            { "authJWT", AuthJWT },
+            { "authPhone", AuthPhone },
+            { "serviceStatusForAccount", ServiceStatusForAccount },
+            { "serviceStatusForAvatars", ServiceStatusForAvatars },
+            { "serviceStatusForDatabases", ServiceStatusForDatabases },
+            { "serviceStatusForTablesdb", ServiceStatusForTablesdb },
+            { "serviceStatusForLocale", ServiceStatusForLocale },
+            { "serviceStatusForHealth", ServiceStatusForHealth },
+            { "serviceStatusForProject", ServiceStatusForProject },
+            { "serviceStatusForStorage", ServiceStatusForStorage },
+            { "serviceStatusForTeams", ServiceStatusForTeams },
+            { "serviceStatusForUsers", ServiceStatusForUsers },
+            { "serviceStatusForVcs", ServiceStatusForVcs },
+            { "serviceStatusForSites", ServiceStatusForSites },
+            { "serviceStatusForFunctions", ServiceStatusForFunctions },
+            { "serviceStatusForProxy", ServiceStatusForProxy },
+            { "serviceStatusForGraphql", ServiceStatusForGraphql },
+            { "serviceStatusForMigrations", ServiceStatusForMigrations },
+            { "serviceStatusForMessaging", ServiceStatusForMessaging },
+            { "protocolStatusForRest", ProtocolStatusForRest },
+            { "protocolStatusForGraphql", ProtocolStatusForGraphql },
+            { "protocolStatusForWebsocket", ProtocolStatusForWebsocket },
+            { "region", Region },
+            { "billingLimits", BillingLimits.ToMap() },
+            { "blocks", Blocks.Select(it => it.ToMap()) },
+            { "consoleAccessedAt", ConsoleAccessedAt }
+        };
+    }
+}

--- a/Appwrite/Models/Webhook.cs
+++ b/Appwrite/Models/Webhook.cs
@@ -29,17 +29,17 @@ namespace Appwrite.Models
         [JsonPropertyName("events")]
         public List<string> Events { get; private set; }
 
-        [JsonPropertyName("security")]
-        public bool Security { get; private set; }
+        [JsonPropertyName("tls")]
+        public bool Tls { get; private set; }
 
-        [JsonPropertyName("httpUser")]
-        public string HttpUser { get; private set; }
+        [JsonPropertyName("authUsername")]
+        public string AuthUsername { get; private set; }
 
-        [JsonPropertyName("httpPass")]
-        public string HttpPass { get; private set; }
+        [JsonPropertyName("authPassword")]
+        public string AuthPassword { get; private set; }
 
-        [JsonPropertyName("signatureKey")]
-        public string SignatureKey { get; private set; }
+        [JsonPropertyName("secret")]
+        public string Secret { get; private set; }
 
         [JsonPropertyName("enabled")]
         public bool Enabled { get; private set; }
@@ -57,10 +57,10 @@ namespace Appwrite.Models
             string name,
             string url,
             List<string> events,
-            bool security,
-            string httpUser,
-            string httpPass,
-            string signatureKey,
+            bool tls,
+            string authUsername,
+            string authPassword,
+            string secret,
             bool enabled,
             string logs,
             long attempts
@@ -71,10 +71,10 @@ namespace Appwrite.Models
             Name = name;
             Url = url;
             Events = events;
-            Security = security;
-            HttpUser = httpUser;
-            HttpPass = httpPass;
-            SignatureKey = signatureKey;
+            Tls = tls;
+            AuthUsername = authUsername;
+            AuthPassword = authPassword;
+            Secret = secret;
             Enabled = enabled;
             Logs = logs;
             Attempts = attempts;
@@ -87,10 +87,10 @@ namespace Appwrite.Models
             name: map["name"].ToString(),
             url: map["url"].ToString(),
             events: map["events"].ConvertToList<string>(),
-            security: (bool)map["security"],
-            httpUser: map["httpUser"].ToString(),
-            httpPass: map["httpPass"].ToString(),
-            signatureKey: map["signatureKey"].ToString(),
+            tls: (bool)map["tls"],
+            authUsername: map["authUsername"].ToString(),
+            authPassword: map["authPassword"].ToString(),
+            secret: map["secret"].ToString(),
             enabled: (bool)map["enabled"],
             logs: map["logs"].ToString(),
             attempts: Convert.ToInt64(map["attempts"])
@@ -104,10 +104,10 @@ namespace Appwrite.Models
             { "name", Name },
             { "url", Url },
             { "events", Events },
-            { "security", Security },
-            { "httpUser", HttpUser },
-            { "httpPass", HttpPass },
-            { "signatureKey", SignatureKey },
+            { "tls", Tls },
+            { "authUsername", AuthUsername },
+            { "authPassword", AuthPassword },
+            { "secret", Secret },
             { "enabled", Enabled },
             { "logs", Logs },
             { "attempts", Attempts }

--- a/Appwrite/Services/Account.cs
+++ b/Appwrite/Services/Account.cs
@@ -31,8 +31,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "GET",
@@ -71,8 +73,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -110,8 +114,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -141,8 +147,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.IdentityList Convert(Dictionary<string, object> it) =>
-                Models.IdentityList.From(map: it);
+            static Models.IdentityList Convert(Dictionary<string, object> it)
+            {
+                return Models.IdentityList.From(map: it);
+            }
 
             return _client.Call<Models.IdentityList>(
                 method: "GET",
@@ -204,8 +212,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.JWT Convert(Dictionary<string, object> it) =>
-                Models.JWT.From(map: it);
+            static Models.JWT Convert(Dictionary<string, object> it)
+            {
+                return Models.JWT.From(map: it);
+            }
 
             return _client.Call<Models.JWT>(
                 method: "POST",
@@ -236,8 +246,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.LogList Convert(Dictionary<string, object> it) =>
-                Models.LogList.From(map: it);
+            static Models.LogList Convert(Dictionary<string, object> it)
+            {
+                return Models.LogList.From(map: it);
+            }
 
             return _client.Call<Models.LogList>(
                 method: "GET",
@@ -267,8 +279,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -302,8 +316,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaType Convert(Dictionary<string, object> it) =>
-                Models.MfaType.From(map: it);
+            static Models.MfaType Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaType.From(map: it);
+            }
 
             return _client.Call<Models.MfaType>(
                 method: "POST",
@@ -336,8 +352,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaType Convert(Dictionary<string, object> it) =>
-                Models.MfaType.From(map: it);
+            static Models.MfaType Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaType.From(map: it);
+            }
 
             return _client.Call<Models.MfaType>(
                 method: "POST",
@@ -371,8 +389,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PUT",
@@ -405,8 +425,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PUT",
@@ -496,8 +518,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaChallenge Convert(Dictionary<string, object> it) =>
-                Models.MfaChallenge.From(map: it);
+            static Models.MfaChallenge Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaChallenge.From(map: it);
+            }
 
             return _client.Call<Models.MfaChallenge>(
                 method: "POST",
@@ -529,8 +553,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaChallenge Convert(Dictionary<string, object> it) =>
-                Models.MfaChallenge.From(map: it);
+            static Models.MfaChallenge Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaChallenge.From(map: it);
+            }
 
             return _client.Call<Models.MfaChallenge>(
                 method: "POST",
@@ -566,8 +592,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "PUT",
@@ -602,8 +630,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "PUT",
@@ -632,8 +662,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaFactors Convert(Dictionary<string, object> it) =>
-                Models.MfaFactors.From(map: it);
+            static Models.MfaFactors Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaFactors.From(map: it);
+            }
 
             return _client.Call<Models.MfaFactors>(
                 method: "GET",
@@ -661,8 +693,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaFactors Convert(Dictionary<string, object> it) =>
-                Models.MfaFactors.From(map: it);
+            static Models.MfaFactors Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaFactors.From(map: it);
+            }
 
             return _client.Call<Models.MfaFactors>(
                 method: "GET",
@@ -694,8 +728,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "GET",
@@ -726,8 +762,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "GET",
@@ -761,8 +799,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "POST",
@@ -795,8 +835,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "POST",
@@ -829,8 +871,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "PATCH",
@@ -862,8 +906,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "PATCH",
@@ -893,8 +939,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -927,8 +975,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -963,8 +1013,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -992,8 +1044,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Preferences Convert(Dictionary<string, object> it) =>
-                Models.Preferences.From(map: it);
+            static Models.Preferences Convert(Dictionary<string, object> it)
+            {
+                return Models.Preferences.From(map: it);
+            }
 
             return _client.Call<Models.Preferences>(
                 method: "GET",
@@ -1025,8 +1079,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -1064,8 +1120,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "POST",
@@ -1106,8 +1164,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "PUT",
@@ -1136,8 +1196,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.SessionList Convert(Dictionary<string, object> it) =>
-                Models.SessionList.From(map: it);
+            static Models.SessionList Convert(Dictionary<string, object> it)
+            {
+                return Models.SessionList.From(map: it);
+            }
 
             return _client.Call<Models.SessionList>(
                 method: "GET",
@@ -1200,8 +1262,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "POST",
@@ -1237,8 +1301,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "POST",
@@ -1272,8 +1338,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "PUT",
@@ -1307,8 +1375,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "PUT",
@@ -1341,8 +1411,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "POST",
@@ -1372,8 +1444,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "GET",
@@ -1405,8 +1479,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "PATCH",
@@ -1469,8 +1545,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -1515,8 +1593,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "POST",
@@ -1562,8 +1642,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "POST",
@@ -1646,8 +1728,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "POST",
@@ -1691,8 +1775,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "POST",
@@ -1737,8 +1823,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "POST",
@@ -1772,8 +1860,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "PUT",
@@ -1808,8 +1898,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "PUT",
@@ -1845,8 +1937,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "POST",
@@ -1880,8 +1974,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "PUT",

--- a/Appwrite/Services/Activities.cs
+++ b/Appwrite/Services/Activities.cs
@@ -32,8 +32,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ActivityEventList Convert(Dictionary<string, object> it) =>
-                Models.ActivityEventList.From(map: it);
+            static Models.ActivityEventList Convert(Dictionary<string, object> it)
+            {
+                return Models.ActivityEventList.From(map: it);
+            }
 
             return _client.Call<Models.ActivityEventList>(
                 method: "GET",
@@ -63,8 +65,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ActivityEvent Convert(Dictionary<string, object> it) =>
-                Models.ActivityEvent.From(map: it);
+            static Models.ActivityEvent Convert(Dictionary<string, object> it)
+            {
+                return Models.ActivityEvent.From(map: it);
+            }
 
             return _client.Call<Models.ActivityEvent>(
                 method: "GET",

--- a/Appwrite/Services/Backups.cs
+++ b/Appwrite/Services/Backups.cs
@@ -32,8 +32,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupArchiveList Convert(Dictionary<string, object> it) =>
-                Models.BackupArchiveList.From(map: it);
+            static Models.BackupArchiveList Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupArchiveList.From(map: it);
+            }
 
             return _client.Call<Models.BackupArchiveList>(
                 method: "GET",
@@ -64,8 +66,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupArchive Convert(Dictionary<string, object> it) =>
-                Models.BackupArchive.From(map: it);
+            static Models.BackupArchive Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupArchive.From(map: it);
+            }
 
             return _client.Call<Models.BackupArchive>(
                 method: "POST",
@@ -94,8 +98,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupArchive Convert(Dictionary<string, object> it) =>
-                Models.BackupArchive.From(map: it);
+            static Models.BackupArchive Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupArchive.From(map: it);
+            }
 
             return _client.Call<Models.BackupArchive>(
                 method: "GET",
@@ -152,8 +158,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupPolicyList Convert(Dictionary<string, object> it) =>
-                Models.BackupPolicyList.From(map: it);
+            static Models.BackupPolicyList Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupPolicyList.From(map: it);
+            }
 
             return _client.Call<Models.BackupPolicyList>(
                 method: "GET",
@@ -189,8 +197,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupPolicy Convert(Dictionary<string, object> it) =>
-                Models.BackupPolicy.From(map: it);
+            static Models.BackupPolicy Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupPolicy.From(map: it);
+            }
 
             return _client.Call<Models.BackupPolicy>(
                 method: "POST",
@@ -219,8 +229,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupPolicy Convert(Dictionary<string, object> it) =>
-                Models.BackupPolicy.From(map: it);
+            static Models.BackupPolicy Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupPolicy.From(map: it);
+            }
 
             return _client.Call<Models.BackupPolicy>(
                 method: "GET",
@@ -254,8 +266,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupPolicy Convert(Dictionary<string, object> it) =>
-                Models.BackupPolicy.From(map: it);
+            static Models.BackupPolicy Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupPolicy.From(map: it);
+            }
 
             return _client.Call<Models.BackupPolicy>(
                 method: "PATCH",
@@ -316,8 +330,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupRestoration Convert(Dictionary<string, object> it) =>
-                Models.BackupRestoration.From(map: it);
+            static Models.BackupRestoration Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupRestoration.From(map: it);
+            }
 
             return _client.Call<Models.BackupRestoration>(
                 method: "POST",
@@ -346,8 +362,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupRestorationList Convert(Dictionary<string, object> it) =>
-                Models.BackupRestorationList.From(map: it);
+            static Models.BackupRestorationList Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupRestorationList.From(map: it);
+            }
 
             return _client.Call<Models.BackupRestorationList>(
                 method: "GET",
@@ -376,8 +394,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BackupRestoration Convert(Dictionary<string, object> it) =>
-                Models.BackupRestoration.From(map: it);
+            static Models.BackupRestoration Convert(Dictionary<string, object> it)
+            {
+                return Models.BackupRestoration.From(map: it);
+            }
 
             return _client.Call<Models.BackupRestoration>(
                 method: "GET",

--- a/Appwrite/Services/Databases.cs
+++ b/Appwrite/Services/Databases.cs
@@ -36,8 +36,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DatabaseList Convert(Dictionary<string, object> it) =>
-                Models.DatabaseList.From(map: it);
+            static Models.DatabaseList Convert(Dictionary<string, object> it)
+            {
+                return Models.DatabaseList.From(map: it);
+            }
 
             return _client.Call<Models.DatabaseList>(
                 method: "GET",
@@ -71,8 +73,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Database Convert(Dictionary<string, object> it) =>
-                Models.Database.From(map: it);
+            static Models.Database Convert(Dictionary<string, object> it)
+            {
+                return Models.Database.From(map: it);
+            }
 
             return _client.Call<Models.Database>(
                 method: "POST",
@@ -101,8 +105,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.TransactionList Convert(Dictionary<string, object> it) =>
-                Models.TransactionList.From(map: it);
+            static Models.TransactionList Convert(Dictionary<string, object> it)
+            {
+                return Models.TransactionList.From(map: it);
+            }
 
             return _client.Call<Models.TransactionList>(
                 method: "GET",
@@ -132,8 +138,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Transaction Convert(Dictionary<string, object> it) =>
-                Models.Transaction.From(map: it);
+            static Models.Transaction Convert(Dictionary<string, object> it)
+            {
+                return Models.Transaction.From(map: it);
+            }
 
             return _client.Call<Models.Transaction>(
                 method: "POST",
@@ -162,8 +170,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Transaction Convert(Dictionary<string, object> it) =>
-                Models.Transaction.From(map: it);
+            static Models.Transaction Convert(Dictionary<string, object> it)
+            {
+                return Models.Transaction.From(map: it);
+            }
 
             return _client.Call<Models.Transaction>(
                 method: "GET",
@@ -195,8 +205,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Transaction Convert(Dictionary<string, object> it) =>
-                Models.Transaction.From(map: it);
+            static Models.Transaction Convert(Dictionary<string, object> it)
+            {
+                return Models.Transaction.From(map: it);
+            }
 
             return _client.Call<Models.Transaction>(
                 method: "PATCH",
@@ -255,8 +267,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Transaction Convert(Dictionary<string, object> it) =>
-                Models.Transaction.From(map: it);
+            static Models.Transaction Convert(Dictionary<string, object> it)
+            {
+                return Models.Transaction.From(map: it);
+            }
 
             return _client.Call<Models.Transaction>(
                 method: "POST",
@@ -287,8 +301,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Database Convert(Dictionary<string, object> it) =>
-                Models.Database.From(map: it);
+            static Models.Database Convert(Dictionary<string, object> it)
+            {
+                return Models.Database.From(map: it);
+            }
 
             return _client.Call<Models.Database>(
                 method: "GET",
@@ -321,8 +337,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Database Convert(Dictionary<string, object> it) =>
-                Models.Database.From(map: it);
+            static Models.Database Convert(Dictionary<string, object> it)
+            {
+                return Models.Database.From(map: it);
+            }
 
             return _client.Call<Models.Database>(
                 method: "PUT",
@@ -386,8 +404,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.CollectionList Convert(Dictionary<string, object> it) =>
-                Models.CollectionList.From(map: it);
+            static Models.CollectionList Convert(Dictionary<string, object> it)
+            {
+                return Models.CollectionList.From(map: it);
+            }
 
             return _client.Call<Models.CollectionList>(
                 method: "GET",
@@ -428,8 +448,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Collection Convert(Dictionary<string, object> it) =>
-                Models.Collection.From(map: it);
+            static Models.Collection Convert(Dictionary<string, object> it)
+            {
+                return Models.Collection.From(map: it);
+            }
 
             return _client.Call<Models.Collection>(
                 method: "POST",
@@ -461,8 +483,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Collection Convert(Dictionary<string, object> it) =>
-                Models.Collection.From(map: it);
+            static Models.Collection Convert(Dictionary<string, object> it)
+            {
+                return Models.Collection.From(map: it);
+            }
 
             return _client.Call<Models.Collection>(
                 method: "GET",
@@ -478,7 +502,7 @@ namespace Appwrite.Services
         /// </para>
         /// </summary>
         [Obsolete("This API has been deprecated since 1.8.0. Please use `TablesDB.updateTable` instead.")]
-        public Task<Models.Collection> UpdateCollection(string databaseId, string collectionId, string? name = null, List<string>? permissions = null, bool? documentSecurity = null, bool? enabled = null)
+        public Task<Models.Collection> UpdateCollection(string databaseId, string collectionId, string? name = null, List<string>? permissions = null, bool? documentSecurity = null, bool? enabled = null, bool? purge = null)
         {
             var apiPath = "/databases/{databaseId}/collections/{collectionId}"
                 .Replace("{databaseId}", databaseId)
@@ -489,7 +513,8 @@ namespace Appwrite.Services
                 { "name", name },
                 { "permissions", permissions },
                 { "documentSecurity", documentSecurity },
-                { "enabled", enabled }
+                { "enabled", enabled },
+                { "purge", purge }
             };
 
             var apiHeaders = new Dictionary<string, string>()
@@ -498,8 +523,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Collection Convert(Dictionary<string, object> it) =>
-                Models.Collection.From(map: it);
+            static Models.Collection Convert(Dictionary<string, object> it)
+            {
+                return Models.Collection.From(map: it);
+            }
 
             return _client.Call<Models.Collection>(
                 method: "PUT",
@@ -563,8 +590,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeList Convert(Dictionary<string, object> it) =>
-                Models.AttributeList.From(map: it);
+            static Models.AttributeList Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeList.From(map: it);
+            }
 
             return _client.Call<Models.AttributeList>(
                 method: "GET",
@@ -601,8 +630,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeBoolean Convert(Dictionary<string, object> it) =>
-                Models.AttributeBoolean.From(map: it);
+            static Models.AttributeBoolean Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeBoolean.From(map: it);
+            }
 
             return _client.Call<Models.AttributeBoolean>(
                 method: "POST",
@@ -639,8 +670,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeBoolean Convert(Dictionary<string, object> it) =>
-                Models.AttributeBoolean.From(map: it);
+            static Models.AttributeBoolean Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeBoolean.From(map: it);
+            }
 
             return _client.Call<Models.AttributeBoolean>(
                 method: "PATCH",
@@ -676,8 +709,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeDatetime Convert(Dictionary<string, object> it) =>
-                Models.AttributeDatetime.From(map: it);
+            static Models.AttributeDatetime Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeDatetime.From(map: it);
+            }
 
             return _client.Call<Models.AttributeDatetime>(
                 method: "POST",
@@ -714,8 +749,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeDatetime Convert(Dictionary<string, object> it) =>
-                Models.AttributeDatetime.From(map: it);
+            static Models.AttributeDatetime Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeDatetime.From(map: it);
+            }
 
             return _client.Call<Models.AttributeDatetime>(
                 method: "PATCH",
@@ -752,8 +789,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeEmail Convert(Dictionary<string, object> it) =>
-                Models.AttributeEmail.From(map: it);
+            static Models.AttributeEmail Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeEmail.From(map: it);
+            }
 
             return _client.Call<Models.AttributeEmail>(
                 method: "POST",
@@ -791,8 +830,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeEmail Convert(Dictionary<string, object> it) =>
-                Models.AttributeEmail.From(map: it);
+            static Models.AttributeEmail Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeEmail.From(map: it);
+            }
 
             return _client.Call<Models.AttributeEmail>(
                 method: "PATCH",
@@ -831,8 +872,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeEnum Convert(Dictionary<string, object> it) =>
-                Models.AttributeEnum.From(map: it);
+            static Models.AttributeEnum Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeEnum.From(map: it);
+            }
 
             return _client.Call<Models.AttributeEnum>(
                 method: "POST",
@@ -871,8 +914,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeEnum Convert(Dictionary<string, object> it) =>
-                Models.AttributeEnum.From(map: it);
+            static Models.AttributeEnum Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeEnum.From(map: it);
+            }
 
             return _client.Call<Models.AttributeEnum>(
                 method: "PATCH",
@@ -912,8 +957,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeFloat Convert(Dictionary<string, object> it) =>
-                Models.AttributeFloat.From(map: it);
+            static Models.AttributeFloat Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeFloat.From(map: it);
+            }
 
             return _client.Call<Models.AttributeFloat>(
                 method: "POST",
@@ -953,8 +1000,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeFloat Convert(Dictionary<string, object> it) =>
-                Models.AttributeFloat.From(map: it);
+            static Models.AttributeFloat Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeFloat.From(map: it);
+            }
 
             return _client.Call<Models.AttributeFloat>(
                 method: "PATCH",
@@ -994,8 +1043,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeInteger Convert(Dictionary<string, object> it) =>
-                Models.AttributeInteger.From(map: it);
+            static Models.AttributeInteger Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeInteger.From(map: it);
+            }
 
             return _client.Call<Models.AttributeInteger>(
                 method: "POST",
@@ -1035,8 +1086,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeInteger Convert(Dictionary<string, object> it) =>
-                Models.AttributeInteger.From(map: it);
+            static Models.AttributeInteger Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeInteger.From(map: it);
+            }
 
             return _client.Call<Models.AttributeInteger>(
                 method: "PATCH",
@@ -1073,8 +1126,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeIp Convert(Dictionary<string, object> it) =>
-                Models.AttributeIp.From(map: it);
+            static Models.AttributeIp Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeIp.From(map: it);
+            }
 
             return _client.Call<Models.AttributeIp>(
                 method: "POST",
@@ -1112,8 +1167,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeIp Convert(Dictionary<string, object> it) =>
-                Models.AttributeIp.From(map: it);
+            static Models.AttributeIp Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeIp.From(map: it);
+            }
 
             return _client.Call<Models.AttributeIp>(
                 method: "PATCH",
@@ -1148,8 +1205,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeLine Convert(Dictionary<string, object> it) =>
-                Models.AttributeLine.From(map: it);
+            static Models.AttributeLine Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeLine.From(map: it);
+            }
 
             return _client.Call<Models.AttributeLine>(
                 method: "POST",
@@ -1186,8 +1245,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeLine Convert(Dictionary<string, object> it) =>
-                Models.AttributeLine.From(map: it);
+            static Models.AttributeLine Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeLine.From(map: it);
+            }
 
             return _client.Call<Models.AttributeLine>(
                 method: "PATCH",
@@ -1224,8 +1285,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeLongtext Convert(Dictionary<string, object> it) =>
-                Models.AttributeLongtext.From(map: it);
+            static Models.AttributeLongtext Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeLongtext.From(map: it);
+            }
 
             return _client.Call<Models.AttributeLongtext>(
                 method: "POST",
@@ -1262,8 +1325,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeLongtext Convert(Dictionary<string, object> it) =>
-                Models.AttributeLongtext.From(map: it);
+            static Models.AttributeLongtext Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeLongtext.From(map: it);
+            }
 
             return _client.Call<Models.AttributeLongtext>(
                 method: "PATCH",
@@ -1300,8 +1365,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeMediumtext Convert(Dictionary<string, object> it) =>
-                Models.AttributeMediumtext.From(map: it);
+            static Models.AttributeMediumtext Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeMediumtext.From(map: it);
+            }
 
             return _client.Call<Models.AttributeMediumtext>(
                 method: "POST",
@@ -1338,8 +1405,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeMediumtext Convert(Dictionary<string, object> it) =>
-                Models.AttributeMediumtext.From(map: it);
+            static Models.AttributeMediumtext Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeMediumtext.From(map: it);
+            }
 
             return _client.Call<Models.AttributeMediumtext>(
                 method: "PATCH",
@@ -1374,8 +1443,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributePoint Convert(Dictionary<string, object> it) =>
-                Models.AttributePoint.From(map: it);
+            static Models.AttributePoint Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributePoint.From(map: it);
+            }
 
             return _client.Call<Models.AttributePoint>(
                 method: "POST",
@@ -1412,8 +1483,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributePoint Convert(Dictionary<string, object> it) =>
-                Models.AttributePoint.From(map: it);
+            static Models.AttributePoint Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributePoint.From(map: it);
+            }
 
             return _client.Call<Models.AttributePoint>(
                 method: "PATCH",
@@ -1448,8 +1521,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributePolygon Convert(Dictionary<string, object> it) =>
-                Models.AttributePolygon.From(map: it);
+            static Models.AttributePolygon Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributePolygon.From(map: it);
+            }
 
             return _client.Call<Models.AttributePolygon>(
                 method: "POST",
@@ -1486,8 +1561,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributePolygon Convert(Dictionary<string, object> it) =>
-                Models.AttributePolygon.From(map: it);
+            static Models.AttributePolygon Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributePolygon.From(map: it);
+            }
 
             return _client.Call<Models.AttributePolygon>(
                 method: "PATCH",
@@ -1527,8 +1604,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeRelationship Convert(Dictionary<string, object> it) =>
-                Models.AttributeRelationship.From(map: it);
+            static Models.AttributeRelationship Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeRelationship.From(map: it);
+            }
 
             return _client.Call<Models.AttributeRelationship>(
                 method: "POST",
@@ -1565,8 +1644,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeRelationship Convert(Dictionary<string, object> it) =>
-                Models.AttributeRelationship.From(map: it);
+            static Models.AttributeRelationship Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeRelationship.From(map: it);
+            }
 
             return _client.Call<Models.AttributeRelationship>(
                 method: "PATCH",
@@ -1605,8 +1686,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeString Convert(Dictionary<string, object> it) =>
-                Models.AttributeString.From(map: it);
+            static Models.AttributeString Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeString.From(map: it);
+            }
 
             return _client.Call<Models.AttributeString>(
                 method: "POST",
@@ -1645,8 +1728,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeString Convert(Dictionary<string, object> it) =>
-                Models.AttributeString.From(map: it);
+            static Models.AttributeString Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeString.From(map: it);
+            }
 
             return _client.Call<Models.AttributeString>(
                 method: "PATCH",
@@ -1683,8 +1768,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeText Convert(Dictionary<string, object> it) =>
-                Models.AttributeText.From(map: it);
+            static Models.AttributeText Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeText.From(map: it);
+            }
 
             return _client.Call<Models.AttributeText>(
                 method: "POST",
@@ -1721,8 +1808,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeText Convert(Dictionary<string, object> it) =>
-                Models.AttributeText.From(map: it);
+            static Models.AttributeText Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeText.From(map: it);
+            }
 
             return _client.Call<Models.AttributeText>(
                 method: "PATCH",
@@ -1759,8 +1848,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeUrl Convert(Dictionary<string, object> it) =>
-                Models.AttributeUrl.From(map: it);
+            static Models.AttributeUrl Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeUrl.From(map: it);
+            }
 
             return _client.Call<Models.AttributeUrl>(
                 method: "POST",
@@ -1798,8 +1889,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeUrl Convert(Dictionary<string, object> it) =>
-                Models.AttributeUrl.From(map: it);
+            static Models.AttributeUrl Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeUrl.From(map: it);
+            }
 
             return _client.Call<Models.AttributeUrl>(
                 method: "PATCH",
@@ -1837,8 +1930,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeVarchar Convert(Dictionary<string, object> it) =>
-                Models.AttributeVarchar.From(map: it);
+            static Models.AttributeVarchar Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeVarchar.From(map: it);
+            }
 
             return _client.Call<Models.AttributeVarchar>(
                 method: "POST",
@@ -1876,8 +1971,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.AttributeVarchar Convert(Dictionary<string, object> it) =>
-                Models.AttributeVarchar.From(map: it);
+            static Models.AttributeVarchar Convert(Dictionary<string, object> it)
+            {
+                return Models.AttributeVarchar.From(map: it);
+            }
 
             return _client.Call<Models.AttributeVarchar>(
                 method: "PATCH",
@@ -1909,8 +2006,10 @@ namespace Appwrite.Services
             };
 
 
-            static object Convert(Dictionary<string, object> it) =>
-                it;
+            static object Convert(Dictionary<string, object> it)
+            {
+                return Appwrite.Models.AttributeBoolean.From(map: it);
+            }
 
             return _client.Call<object>(
                 method: "GET",
@@ -1977,8 +2076,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DocumentList Convert(Dictionary<string, object> it) =>
-                Models.DocumentList.From(map: it);
+            static Models.DocumentList Convert(Dictionary<string, object> it)
+            {
+                return Models.DocumentList.From(map: it);
+            }
 
             return _client.Call<Models.DocumentList>(
                 method: "GET",
@@ -2017,8 +2118,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Document Convert(Dictionary<string, object> it) =>
-                Models.Document.From(map: it);
+            static Models.Document Convert(Dictionary<string, object> it)
+            {
+                return Models.Document.From(map: it);
+            }
 
             return _client.Call<Models.Document>(
                 method: "POST",
@@ -2055,8 +2158,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DocumentList Convert(Dictionary<string, object> it) =>
-                Models.DocumentList.From(map: it);
+            static Models.DocumentList Convert(Dictionary<string, object> it)
+            {
+                return Models.DocumentList.From(map: it);
+            }
 
             return _client.Call<Models.DocumentList>(
                 method: "POST",
@@ -2094,8 +2199,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DocumentList Convert(Dictionary<string, object> it) =>
-                Models.DocumentList.From(map: it);
+            static Models.DocumentList Convert(Dictionary<string, object> it)
+            {
+                return Models.DocumentList.From(map: it);
+            }
 
             return _client.Call<Models.DocumentList>(
                 method: "PUT",
@@ -2132,8 +2239,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DocumentList Convert(Dictionary<string, object> it) =>
-                Models.DocumentList.From(map: it);
+            static Models.DocumentList Convert(Dictionary<string, object> it)
+            {
+                return Models.DocumentList.From(map: it);
+            }
 
             return _client.Call<Models.DocumentList>(
                 method: "PATCH",
@@ -2168,8 +2277,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DocumentList Convert(Dictionary<string, object> it) =>
-                Models.DocumentList.From(map: it);
+            static Models.DocumentList Convert(Dictionary<string, object> it)
+            {
+                return Models.DocumentList.From(map: it);
+            }
 
             return _client.Call<Models.DocumentList>(
                 method: "DELETE",
@@ -2204,8 +2315,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Document Convert(Dictionary<string, object> it) =>
-                Models.Document.From(map: it);
+            static Models.Document Convert(Dictionary<string, object> it)
+            {
+                return Models.Document.From(map: it);
+            }
 
             return _client.Call<Models.Document>(
                 method: "GET",
@@ -2244,8 +2357,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Document Convert(Dictionary<string, object> it) =>
-                Models.Document.From(map: it);
+            static Models.Document Convert(Dictionary<string, object> it)
+            {
+                return Models.Document.From(map: it);
+            }
 
             return _client.Call<Models.Document>(
                 method: "PUT",
@@ -2282,8 +2397,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Document Convert(Dictionary<string, object> it) =>
-                Models.Document.From(map: it);
+            static Models.Document Convert(Dictionary<string, object> it)
+            {
+                return Models.Document.From(map: it);
+            }
 
             return _client.Call<Models.Document>(
                 method: "PATCH",
@@ -2352,8 +2469,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Document Convert(Dictionary<string, object> it) =>
-                Models.Document.From(map: it);
+            static Models.Document Convert(Dictionary<string, object> it)
+            {
+                return Models.Document.From(map: it);
+            }
 
             return _client.Call<Models.Document>(
                 method: "PATCH",
@@ -2390,8 +2509,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Document Convert(Dictionary<string, object> it) =>
-                Models.Document.From(map: it);
+            static Models.Document Convert(Dictionary<string, object> it)
+            {
+                return Models.Document.From(map: it);
+            }
 
             return _client.Call<Models.Document>(
                 method: "PATCH",
@@ -2424,8 +2545,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.IndexList Convert(Dictionary<string, object> it) =>
-                Models.IndexList.From(map: it);
+            static Models.IndexList Convert(Dictionary<string, object> it)
+            {
+                return Models.IndexList.From(map: it);
+            }
 
             return _client.Call<Models.IndexList>(
                 method: "GET",
@@ -2464,8 +2587,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Index Convert(Dictionary<string, object> it) =>
-                Models.Index.From(map: it);
+            static Models.Index Convert(Dictionary<string, object> it)
+            {
+                return Models.Index.From(map: it);
+            }
 
             return _client.Call<Models.Index>(
                 method: "POST",
@@ -2497,8 +2622,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Index Convert(Dictionary<string, object> it) =>
-                Models.Index.From(map: it);
+            static Models.Index Convert(Dictionary<string, object> it)
+            {
+                return Models.Index.From(map: it);
+            }
 
             return _client.Call<Models.Index>(
                 method: "GET",

--- a/Appwrite/Services/Databases.cs
+++ b/Appwrite/Services/Databases.cs
@@ -2008,7 +2008,47 @@ namespace Appwrite.Services
 
             static object Convert(Dictionary<string, object> it)
             {
-                return Appwrite.Models.AttributeBoolean.From(map: it);
+                if (it.TryGetValue("type", out var typeValue1) && typeValue1?.ToString() == "string" && it.TryGetValue("format", out var formatValue1) && formatValue1?.ToString() == "email")
+                {
+                    return Appwrite.Models.AttributeEmail.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue2) && typeValue2?.ToString() == "string" && it.TryGetValue("format", out var formatValue2) && formatValue2?.ToString() == "enum")
+                {
+                    return Appwrite.Models.AttributeEnum.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue3) && typeValue3?.ToString() == "string" && it.TryGetValue("format", out var formatValue3) && formatValue3?.ToString() == "url")
+                {
+                    return Appwrite.Models.AttributeUrl.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue4) && typeValue4?.ToString() == "string" && it.TryGetValue("format", out var formatValue4) && formatValue4?.ToString() == "ip")
+                {
+                    return Appwrite.Models.AttributeIp.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue5) && typeValue5?.ToString() == "boolean")
+                {
+                    return Appwrite.Models.AttributeBoolean.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue6) && typeValue6?.ToString() == "integer")
+                {
+                    return Appwrite.Models.AttributeInteger.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue7) && typeValue7?.ToString() == "double")
+                {
+                    return Appwrite.Models.AttributeFloat.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue8) && typeValue8?.ToString() == "datetime")
+                {
+                    return Appwrite.Models.AttributeDatetime.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue9) && typeValue9?.ToString() == "relationship")
+                {
+                    return Appwrite.Models.AttributeRelationship.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue10) && typeValue10?.ToString() == "string")
+                {
+                    return Appwrite.Models.AttributeString.From(map: it);
+                }
+                throw new System.Exception("Unable to match response to any expected response model");
             }
 
             return _client.Call<object>(

--- a/Appwrite/Services/Functions.cs
+++ b/Appwrite/Services/Functions.cs
@@ -35,8 +35,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.FunctionList Convert(Dictionary<string, object> it) =>
-                Models.FunctionList.From(map: it);
+            static Models.FunctionList Convert(Dictionary<string, object> it)
+            {
+                return Models.FunctionList.From(map: it);
+            }
 
             return _client.Call<Models.FunctionList>(
                 method: "GET",
@@ -88,8 +90,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Function Convert(Dictionary<string, object> it) =>
-                Models.Function.From(map: it);
+            static Models.Function Convert(Dictionary<string, object> it)
+            {
+                return Models.Function.From(map: it);
+            }
 
             return _client.Call<Models.Function>(
                 method: "POST",
@@ -117,8 +121,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.RuntimeList Convert(Dictionary<string, object> it) =>
-                Models.RuntimeList.From(map: it);
+            static Models.RuntimeList Convert(Dictionary<string, object> it)
+            {
+                return Models.RuntimeList.From(map: it);
+            }
 
             return _client.Call<Models.RuntimeList>(
                 method: "GET",
@@ -146,8 +152,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.SpecificationList Convert(Dictionary<string, object> it) =>
-                Models.SpecificationList.From(map: it);
+            static Models.SpecificationList Convert(Dictionary<string, object> it)
+            {
+                return Models.SpecificationList.From(map: it);
+            }
 
             return _client.Call<Models.SpecificationList>(
                 method: "GET",
@@ -176,8 +184,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Function Convert(Dictionary<string, object> it) =>
-                Models.Function.From(map: it);
+            static Models.Function Convert(Dictionary<string, object> it)
+            {
+                return Models.Function.From(map: it);
+            }
 
             return _client.Call<Models.Function>(
                 method: "GET",
@@ -226,8 +236,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Function Convert(Dictionary<string, object> it) =>
-                Models.Function.From(map: it);
+            static Models.Function Convert(Dictionary<string, object> it)
+            {
+                return Models.Function.From(map: it);
+            }
 
             return _client.Call<Models.Function>(
                 method: "PUT",
@@ -287,8 +299,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Function Convert(Dictionary<string, object> it) =>
-                Models.Function.From(map: it);
+            static Models.Function Convert(Dictionary<string, object> it)
+            {
+                return Models.Function.From(map: it);
+            }
 
             return _client.Call<Models.Function>(
                 method: "PATCH",
@@ -321,8 +335,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DeploymentList Convert(Dictionary<string, object> it) =>
-                Models.DeploymentList.From(map: it);
+            static Models.DeploymentList Convert(Dictionary<string, object> it)
+            {
+                return Models.DeploymentList.From(map: it);
+            }
 
             return _client.Call<Models.DeploymentList>(
                 method: "GET",
@@ -365,8 +381,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             string? idParamName = null;
 
@@ -407,8 +425,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "POST",
@@ -448,8 +468,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "POST",
@@ -484,8 +506,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "POST",
@@ -515,8 +539,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "GET",
@@ -611,8 +637,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "PATCH",
@@ -644,8 +672,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ExecutionList Convert(Dictionary<string, object> it) =>
-                Models.ExecutionList.From(map: it);
+            static Models.ExecutionList Convert(Dictionary<string, object> it)
+            {
+                return Models.ExecutionList.From(map: it);
+            }
 
             return _client.Call<Models.ExecutionList>(
                 method: "GET",
@@ -684,8 +714,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Execution Convert(Dictionary<string, object> it) =>
-                Models.Execution.From(map: it);
+            static Models.Execution Convert(Dictionary<string, object> it)
+            {
+                return Models.Execution.From(map: it);
+            }
 
             return _client.Call<Models.Execution>(
                 method: "POST",
@@ -715,8 +747,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Execution Convert(Dictionary<string, object> it) =>
-                Models.Execution.From(map: it);
+            static Models.Execution Convert(Dictionary<string, object> it)
+            {
+                return Models.Execution.From(map: it);
+            }
 
             return _client.Call<Models.Execution>(
                 method: "GET",
@@ -774,8 +808,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.VariableList Convert(Dictionary<string, object> it) =>
-                Models.VariableList.From(map: it);
+            static Models.VariableList Convert(Dictionary<string, object> it)
+            {
+                return Models.VariableList.From(map: it);
+            }
 
             return _client.Call<Models.VariableList>(
                 method: "GET",
@@ -809,8 +845,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "POST",
@@ -840,8 +878,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "GET",
@@ -875,8 +915,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "PUT",

--- a/Appwrite/Services/Graphql.cs
+++ b/Appwrite/Services/Graphql.cs
@@ -34,8 +34,10 @@ namespace Appwrite.Services
             };
 
 
-            static object Convert(Dictionary<string, object> it) =>
-                it;
+            static object Convert(Dictionary<string, object> it)
+            {
+                return it;
+            }
 
             return _client.Call<object>(
                 method: "POST",
@@ -66,8 +68,10 @@ namespace Appwrite.Services
             };
 
 
-            static object Convert(Dictionary<string, object> it) =>
-                it;
+            static object Convert(Dictionary<string, object> it)
+            {
+                return it;
+            }
 
             return _client.Call<object>(
                 method: "POST",

--- a/Appwrite/Services/Health.cs
+++ b/Appwrite/Services/Health.cs
@@ -31,8 +31,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthStatus Convert(Dictionary<string, object> it) =>
-                Models.HealthStatus.From(map: it);
+            static Models.HealthStatus Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthStatus.From(map: it);
+            }
 
             return _client.Call<Models.HealthStatus>(
                 method: "GET",
@@ -60,8 +62,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthAntivirus Convert(Dictionary<string, object> it) =>
-                Models.HealthAntivirus.From(map: it);
+            static Models.HealthAntivirus Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthAntivirus.From(map: it);
+            }
 
             return _client.Call<Models.HealthAntivirus>(
                 method: "GET",
@@ -90,8 +94,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthStatusList Convert(Dictionary<string, object> it) =>
-                Models.HealthStatusList.From(map: it);
+            static Models.HealthStatusList Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthStatusList.From(map: it);
+            }
 
             return _client.Call<Models.HealthStatusList>(
                 method: "GET",
@@ -120,8 +126,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthCertificate Convert(Dictionary<string, object> it) =>
-                Models.HealthCertificate.From(map: it);
+            static Models.HealthCertificate Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthCertificate.From(map: it);
+            }
 
             return _client.Call<Models.HealthCertificate>(
                 method: "GET",
@@ -153,8 +161,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthStatus Convert(Dictionary<string, object> it) =>
-                Models.HealthStatus.From(map: it);
+            static Models.HealthStatus Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthStatus.From(map: it);
+            }
 
             return _client.Call<Models.HealthStatus>(
                 method: "GET",
@@ -182,8 +192,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthStatusList Convert(Dictionary<string, object> it) =>
-                Models.HealthStatusList.From(map: it);
+            static Models.HealthStatusList Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthStatusList.From(map: it);
+            }
 
             return _client.Call<Models.HealthStatusList>(
                 method: "GET",
@@ -211,8 +223,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthStatusList Convert(Dictionary<string, object> it) =>
-                Models.HealthStatusList.From(map: it);
+            static Models.HealthStatusList Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthStatusList.From(map: it);
+            }
 
             return _client.Call<Models.HealthStatusList>(
                 method: "GET",
@@ -226,6 +240,7 @@ namespace Appwrite.Services
         /// <para>
         /// Get the number of audit logs that are waiting to be processed in the
         /// Appwrite internal queue server.
+        /// 
         /// </para>
         /// </summary>
         public Task<Models.HealthQueue> GetQueueAudits(long? threshold = null)
@@ -242,8 +257,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -273,8 +290,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -305,8 +324,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -337,8 +358,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -368,8 +391,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -400,8 +425,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -431,8 +458,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -462,8 +491,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -493,8 +524,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -524,8 +557,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -555,8 +590,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -586,8 +623,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -617,8 +656,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -648,8 +689,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthQueue Convert(Dictionary<string, object> it) =>
-                Models.HealthQueue.From(map: it);
+            static Models.HealthQueue Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthQueue.From(map: it);
+            }
 
             return _client.Call<Models.HealthQueue>(
                 method: "GET",
@@ -677,8 +720,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthStatus Convert(Dictionary<string, object> it) =>
-                Models.HealthStatus.From(map: it);
+            static Models.HealthStatus Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthStatus.From(map: it);
+            }
 
             return _client.Call<Models.HealthStatus>(
                 method: "GET",
@@ -706,8 +751,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthStatus Convert(Dictionary<string, object> it) =>
-                Models.HealthStatus.From(map: it);
+            static Models.HealthStatus Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthStatus.From(map: it);
+            }
 
             return _client.Call<Models.HealthStatus>(
                 method: "GET",
@@ -741,8 +788,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.HealthTime Convert(Dictionary<string, object> it) =>
-                Models.HealthTime.From(map: it);
+            static Models.HealthTime Convert(Dictionary<string, object> it)
+            {
+                return Models.HealthTime.From(map: it);
+            }
 
             return _client.Call<Models.HealthTime>(
                 method: "GET",

--- a/Appwrite/Services/Locale.cs
+++ b/Appwrite/Services/Locale.cs
@@ -36,8 +36,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Locale Convert(Dictionary<string, object> it) =>
-                Models.Locale.From(map: it);
+            static Models.Locale Convert(Dictionary<string, object> it)
+            {
+                return Models.Locale.From(map: it);
+            }
 
             return _client.Call<Models.Locale>(
                 method: "GET",
@@ -66,8 +68,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.LocaleCodeList Convert(Dictionary<string, object> it) =>
-                Models.LocaleCodeList.From(map: it);
+            static Models.LocaleCodeList Convert(Dictionary<string, object> it)
+            {
+                return Models.LocaleCodeList.From(map: it);
+            }
 
             return _client.Call<Models.LocaleCodeList>(
                 method: "GET",
@@ -96,8 +100,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ContinentList Convert(Dictionary<string, object> it) =>
-                Models.ContinentList.From(map: it);
+            static Models.ContinentList Convert(Dictionary<string, object> it)
+            {
+                return Models.ContinentList.From(map: it);
+            }
 
             return _client.Call<Models.ContinentList>(
                 method: "GET",
@@ -126,8 +132,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.CountryList Convert(Dictionary<string, object> it) =>
-                Models.CountryList.From(map: it);
+            static Models.CountryList Convert(Dictionary<string, object> it)
+            {
+                return Models.CountryList.From(map: it);
+            }
 
             return _client.Call<Models.CountryList>(
                 method: "GET",
@@ -156,8 +164,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.CountryList Convert(Dictionary<string, object> it) =>
-                Models.CountryList.From(map: it);
+            static Models.CountryList Convert(Dictionary<string, object> it)
+            {
+                return Models.CountryList.From(map: it);
+            }
 
             return _client.Call<Models.CountryList>(
                 method: "GET",
@@ -186,8 +196,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.PhoneList Convert(Dictionary<string, object> it) =>
-                Models.PhoneList.From(map: it);
+            static Models.PhoneList Convert(Dictionary<string, object> it)
+            {
+                return Models.PhoneList.From(map: it);
+            }
 
             return _client.Call<Models.PhoneList>(
                 method: "GET",
@@ -217,8 +229,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.CurrencyList Convert(Dictionary<string, object> it) =>
-                Models.CurrencyList.From(map: it);
+            static Models.CurrencyList Convert(Dictionary<string, object> it)
+            {
+                return Models.CurrencyList.From(map: it);
+            }
 
             return _client.Call<Models.CurrencyList>(
                 method: "GET",
@@ -247,8 +261,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.LanguageList Convert(Dictionary<string, object> it) =>
-                Models.LanguageList.From(map: it);
+            static Models.LanguageList Convert(Dictionary<string, object> it)
+            {
+                return Models.LanguageList.From(map: it);
+            }
 
             return _client.Call<Models.LanguageList>(
                 method: "GET",

--- a/Appwrite/Services/Messaging.cs
+++ b/Appwrite/Services/Messaging.cs
@@ -34,8 +34,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MessageList Convert(Dictionary<string, object> it) =>
-                Models.MessageList.From(map: it);
+            static Models.MessageList Convert(Dictionary<string, object> it)
+            {
+                return Models.MessageList.From(map: it);
+            }
 
             return _client.Call<Models.MessageList>(
                 method: "GET",
@@ -76,8 +78,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "POST",
@@ -121,8 +125,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "PATCH",
@@ -170,8 +176,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "POST",
@@ -222,8 +230,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "PATCH",
@@ -260,8 +270,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "POST",
@@ -297,8 +309,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "POST",
@@ -338,8 +352,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "PATCH",
@@ -378,8 +394,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "PATCH",
@@ -409,8 +427,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Message Convert(Dictionary<string, object> it) =>
-                Models.Message.From(map: it);
+            static Models.Message Convert(Dictionary<string, object> it)
+            {
+                return Models.Message.From(map: it);
+            }
 
             return _client.Call<Models.Message>(
                 method: "GET",
@@ -470,8 +490,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.LogList Convert(Dictionary<string, object> it) =>
-                Models.LogList.From(map: it);
+            static Models.LogList Convert(Dictionary<string, object> it)
+            {
+                return Models.LogList.From(map: it);
+            }
 
             return _client.Call<Models.LogList>(
                 method: "GET",
@@ -502,8 +524,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.TargetList Convert(Dictionary<string, object> it) =>
-                Models.TargetList.From(map: it);
+            static Models.TargetList Convert(Dictionary<string, object> it)
+            {
+                return Models.TargetList.From(map: it);
+            }
 
             return _client.Call<Models.TargetList>(
                 method: "GET",
@@ -534,8 +558,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ProviderList Convert(Dictionary<string, object> it) =>
-                Models.ProviderList.From(map: it);
+            static Models.ProviderList Convert(Dictionary<string, object> it)
+            {
+                return Models.ProviderList.From(map: it);
+            }
 
             return _client.Call<Models.ProviderList>(
                 method: "GET",
@@ -573,8 +599,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -611,8 +639,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -650,8 +680,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -688,8 +720,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -723,8 +757,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -757,8 +793,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -792,8 +830,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -826,8 +866,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -866,8 +908,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -906,8 +950,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -942,8 +988,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -978,8 +1026,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1016,8 +1066,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -1054,8 +1106,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1092,8 +1146,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -1130,8 +1186,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1175,8 +1233,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -1219,8 +1279,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -1264,8 +1326,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1308,8 +1372,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1344,8 +1410,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -1380,8 +1448,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1416,8 +1486,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -1452,8 +1524,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1488,8 +1562,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -1524,8 +1600,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1560,8 +1638,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "POST",
@@ -1596,8 +1676,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "PATCH",
@@ -1627,8 +1709,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Provider Convert(Dictionary<string, object> it) =>
-                Models.Provider.From(map: it);
+            static Models.Provider Convert(Dictionary<string, object> it)
+            {
+                return Models.Provider.From(map: it);
+            }
 
             return _client.Call<Models.Provider>(
                 method: "GET",
@@ -1687,8 +1771,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.LogList Convert(Dictionary<string, object> it) =>
-                Models.LogList.From(map: it);
+            static Models.LogList Convert(Dictionary<string, object> it)
+            {
+                return Models.LogList.From(map: it);
+            }
 
             return _client.Call<Models.LogList>(
                 method: "GET",
@@ -1719,8 +1805,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.LogList Convert(Dictionary<string, object> it) =>
-                Models.LogList.From(map: it);
+            static Models.LogList Convert(Dictionary<string, object> it)
+            {
+                return Models.LogList.From(map: it);
+            }
 
             return _client.Call<Models.LogList>(
                 method: "GET",
@@ -1751,8 +1839,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.TopicList Convert(Dictionary<string, object> it) =>
-                Models.TopicList.From(map: it);
+            static Models.TopicList Convert(Dictionary<string, object> it)
+            {
+                return Models.TopicList.From(map: it);
+            }
 
             return _client.Call<Models.TopicList>(
                 method: "GET",
@@ -1784,8 +1874,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Topic Convert(Dictionary<string, object> it) =>
-                Models.Topic.From(map: it);
+            static Models.Topic Convert(Dictionary<string, object> it)
+            {
+                return Models.Topic.From(map: it);
+            }
 
             return _client.Call<Models.Topic>(
                 method: "POST",
@@ -1815,8 +1907,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Topic Convert(Dictionary<string, object> it) =>
-                Models.Topic.From(map: it);
+            static Models.Topic Convert(Dictionary<string, object> it)
+            {
+                return Models.Topic.From(map: it);
+            }
 
             return _client.Call<Models.Topic>(
                 method: "GET",
@@ -1849,8 +1943,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Topic Convert(Dictionary<string, object> it) =>
-                Models.Topic.From(map: it);
+            static Models.Topic Convert(Dictionary<string, object> it)
+            {
+                return Models.Topic.From(map: it);
+            }
 
             return _client.Call<Models.Topic>(
                 method: "PATCH",
@@ -1909,8 +2005,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.LogList Convert(Dictionary<string, object> it) =>
-                Models.LogList.From(map: it);
+            static Models.LogList Convert(Dictionary<string, object> it)
+            {
+                return Models.LogList.From(map: it);
+            }
 
             return _client.Call<Models.LogList>(
                 method: "GET",
@@ -1942,8 +2040,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.SubscriberList Convert(Dictionary<string, object> it) =>
-                Models.SubscriberList.From(map: it);
+            static Models.SubscriberList Convert(Dictionary<string, object> it)
+            {
+                return Models.SubscriberList.From(map: it);
+            }
 
             return _client.Call<Models.SubscriberList>(
                 method: "GET",
@@ -1975,8 +2075,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Subscriber Convert(Dictionary<string, object> it) =>
-                Models.Subscriber.From(map: it);
+            static Models.Subscriber Convert(Dictionary<string, object> it)
+            {
+                return Models.Subscriber.From(map: it);
+            }
 
             return _client.Call<Models.Subscriber>(
                 method: "POST",
@@ -2007,8 +2109,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Subscriber Convert(Dictionary<string, object> it) =>
-                Models.Subscriber.From(map: it);
+            static Models.Subscriber Convert(Dictionary<string, object> it)
+            {
+                return Models.Subscriber.From(map: it);
+            }
 
             return _client.Call<Models.Subscriber>(
                 method: "GET",

--- a/Appwrite/Services/Project.cs
+++ b/Appwrite/Services/Project.cs
@@ -15,6 +15,739 @@ namespace Appwrite.Services
         }
 
         /// <para>
+        /// Get a list of all API keys from the current project.
+        /// </para>
+        /// </summary>
+        public Task<Models.KeyList> ListKeys(List<string>? queries = null, bool? total = null)
+        {
+            var apiPath = "/project/keys";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "queries", queries },
+                { "total", total }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+            };
+
+
+            static Models.KeyList Convert(Dictionary<string, object> it)
+            {
+                return Models.KeyList.From(map: it);
+            }
+
+            return _client.Call<Models.KeyList>(
+                method: "GET",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Create a new API key. It's recommended to have multiple API keys with
+        /// strict scopes for separate functions within your project.
+        /// </para>
+        /// </summary>
+        public Task<Models.Key> CreateKey(string keyId, string name, List<Appwrite.Enums.Scopes> scopes, string? expire = null)
+        {
+            var apiPath = "/project/keys";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "keyId", keyId },
+                { "name", name },
+                { "scopes", scopes?.Select(e => e.Value).ToList() },
+                { "expire", expire }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.Key Convert(Dictionary<string, object> it)
+            {
+                return Models.Key.From(map: it);
+            }
+
+            return _client.Call<Models.Key>(
+                method: "POST",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Get a key by its unique ID. 
+        /// </para>
+        /// </summary>
+        public Task<Models.Key> GetKey(string keyId)
+        {
+            var apiPath = "/project/keys/{keyId}"
+                .Replace("{keyId}", keyId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+            };
+
+
+            static Models.Key Convert(Dictionary<string, object> it)
+            {
+                return Models.Key.From(map: it);
+            }
+
+            return _client.Call<Models.Key>(
+                method: "GET",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Update a key by its unique ID. Use this endpoint to update the name,
+        /// scopes, or expiration time of an API key.
+        /// </para>
+        /// </summary>
+        public Task<Models.Key> UpdateKey(string keyId, string name, List<Appwrite.Enums.Scopes> scopes, string? expire = null)
+        {
+            var apiPath = "/project/keys/{keyId}"
+                .Replace("{keyId}", keyId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "name", name },
+                { "scopes", scopes?.Select(e => e.Value).ToList() },
+                { "expire", expire }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.Key Convert(Dictionary<string, object> it)
+            {
+                return Models.Key.From(map: it);
+            }
+
+            return _client.Call<Models.Key>(
+                method: "PUT",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Delete a key by its unique ID. Once deleted, the key can no longer be used
+        /// to authenticate API calls.
+        /// </para>
+        /// </summary>
+        public Task<object> DeleteKey(string keyId)
+        {
+            var apiPath = "/project/keys/{keyId}"
+                .Replace("{keyId}", keyId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+
+            return _client.Call<object>(
+                method: "DELETE",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!);
+
+        }
+
+        /// <para>
+        /// Update the project labels. Labels can be used to easily filter projects in
+        /// an organization.
+        /// </para>
+        /// </summary>
+        public Task<Models.Project> UpdateLabels(List<string> labels)
+        {
+            var apiPath = "/project/labels";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "labels", labels }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.Project Convert(Dictionary<string, object> it)
+            {
+                return Models.Project.From(map: it);
+            }
+
+            return _client.Call<Models.Project>(
+                method: "PUT",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Get a list of all platforms in the project. This endpoint returns an array
+        /// of all platforms and their configurations.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformList> ListPlatforms(List<string>? queries = null, bool? total = null)
+        {
+            var apiPath = "/project/platforms";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "queries", queries },
+                { "total", total }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+            };
+
+
+            static Models.PlatformList Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformList.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformList>(
+                method: "GET",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Create a new Android platform for your project. Use this endpoint to
+        /// register a new Android platform where your users will run your application
+        /// which will interact with the Appwrite API.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformAndroid> CreateAndroidPlatform(string platformId, string name, string applicationId)
+        {
+            var apiPath = "/project/platforms/android";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "platformId", platformId },
+                { "name", name },
+                { "applicationId", applicationId }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformAndroid Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformAndroid.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformAndroid>(
+                method: "POST",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Update an Android platform by its unique ID. Use this endpoint to update
+        /// the platform's name or application ID.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformAndroid> UpdateAndroidPlatform(string platformId, string name, string applicationId)
+        {
+            var apiPath = "/project/platforms/android/{platformId}"
+                .Replace("{platformId}", platformId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "name", name },
+                { "applicationId", applicationId }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformAndroid Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformAndroid.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformAndroid>(
+                method: "PUT",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Create a new Apple platform for your project. Use this endpoint to register
+        /// a new Apple platform where your users will run your application which will
+        /// interact with the Appwrite API.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformApple> CreateApplePlatform(string platformId, string name, string bundleIdentifier)
+        {
+            var apiPath = "/project/platforms/apple";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "platformId", platformId },
+                { "name", name },
+                { "bundleIdentifier", bundleIdentifier }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformApple Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformApple.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformApple>(
+                method: "POST",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Update an Apple platform by its unique ID. Use this endpoint to update the
+        /// platform's name or bundle identifier.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformApple> UpdateApplePlatform(string platformId, string name, string bundleIdentifier)
+        {
+            var apiPath = "/project/platforms/apple/{platformId}"
+                .Replace("{platformId}", platformId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "name", name },
+                { "bundleIdentifier", bundleIdentifier }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformApple Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformApple.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformApple>(
+                method: "PUT",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Create a new Linux platform for your project. Use this endpoint to register
+        /// a new Linux platform where your users will run your application which will
+        /// interact with the Appwrite API.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformLinux> CreateLinuxPlatform(string platformId, string name, string packageName)
+        {
+            var apiPath = "/project/platforms/linux";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "platformId", platformId },
+                { "name", name },
+                { "packageName", packageName }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformLinux Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformLinux.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformLinux>(
+                method: "POST",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Update a Linux platform by its unique ID. Use this endpoint to update the
+        /// platform's name or package name.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformLinux> UpdateLinuxPlatform(string platformId, string name, string packageName)
+        {
+            var apiPath = "/project/platforms/linux/{platformId}"
+                .Replace("{platformId}", platformId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "name", name },
+                { "packageName", packageName }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformLinux Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformLinux.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformLinux>(
+                method: "PUT",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Create a new web platform for your project. Use this endpoint to register a
+        /// new platform where your users will run your application which will interact
+        /// with the Appwrite API.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformWeb> CreateWebPlatform(string platformId, string name, string hostname)
+        {
+            var apiPath = "/project/platforms/web";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "platformId", platformId },
+                { "name", name },
+                { "hostname", hostname }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformWeb Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformWeb.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformWeb>(
+                method: "POST",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Update a web platform by its unique ID. Use this endpoint to update the
+        /// platform's name or hostname.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformWeb> UpdateWebPlatform(string platformId, string name, string hostname)
+        {
+            var apiPath = "/project/platforms/web/{platformId}"
+                .Replace("{platformId}", platformId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "name", name },
+                { "hostname", hostname }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformWeb Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformWeb.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformWeb>(
+                method: "PUT",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Create a new Windows platform for your project. Use this endpoint to
+        /// register a new Windows platform where your users will run your application
+        /// which will interact with the Appwrite API.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformWindows> CreateWindowsPlatform(string platformId, string name, string packageIdentifierName)
+        {
+            var apiPath = "/project/platforms/windows";
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "platformId", platformId },
+                { "name", name },
+                { "packageIdentifierName", packageIdentifierName }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformWindows Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformWindows.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformWindows>(
+                method: "POST",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Update a Windows platform by its unique ID. Use this endpoint to update the
+        /// platform's name or package identifier name.
+        /// </para>
+        /// </summary>
+        public Task<Models.PlatformWindows> UpdateWindowsPlatform(string platformId, string name, string packageIdentifierName)
+        {
+            var apiPath = "/project/platforms/windows/{platformId}"
+                .Replace("{platformId}", platformId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "name", name },
+                { "packageIdentifierName", packageIdentifierName }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.PlatformWindows Convert(Dictionary<string, object> it)
+            {
+                return Models.PlatformWindows.From(map: it);
+            }
+
+            return _client.Call<Models.PlatformWindows>(
+                method: "PUT",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Get a platform by its unique ID. This endpoint returns the platform's
+        /// details, including its name, type, and key configurations.
+        /// </para>
+        /// </summary>
+        public Task<object> GetPlatform(string platformId)
+        {
+            var apiPath = "/project/platforms/{platformId}"
+                .Replace("{platformId}", platformId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+            };
+
+
+            static object Convert(Dictionary<string, object> it)
+            {
+                return Appwrite.Models.PlatformWeb.From(map: it);
+            }
+
+            return _client.Call<object>(
+                method: "GET",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Delete a platform by its unique ID. This endpoint removes the platform and
+        /// all its configurations from the project.
+        /// </para>
+        /// </summary>
+        public Task<object> DeletePlatform(string platformId)
+        {
+            var apiPath = "/project/platforms/{platformId}"
+                .Replace("{platformId}", platformId);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+
+            return _client.Call<object>(
+                method: "DELETE",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!);
+
+        }
+
+        /// <para>
+        /// Update the status of a specific protocol. Use this endpoint to enable or
+        /// disable a protocol in your project. 
+        /// </para>
+        /// </summary>
+        public Task<Models.Project> UpdateProtocolStatus(Appwrite.Enums.ProtocolId protocolId, bool enabled)
+        {
+            var apiPath = "/project/protocols/{protocolId}/status"
+                .Replace("{protocolId}", protocolId.Value);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "enabled", enabled }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.Project Convert(Dictionary<string, object> it)
+            {
+                return Models.Project.From(map: it);
+            }
+
+            return _client.Call<Models.Project>(
+                method: "PATCH",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
+        /// Update the status of a specific service. Use this endpoint to enable or
+        /// disable a service in your project. 
+        /// </para>
+        /// </summary>
+        public Task<Models.Project> UpdateServiceStatus(Appwrite.Enums.ServiceId serviceId, bool enabled)
+        {
+            var apiPath = "/project/services/{serviceId}/status"
+                .Replace("{serviceId}", serviceId.Value);
+
+            var apiParameters = new Dictionary<string, object?>()
+            {
+                { "enabled", enabled }
+            };
+
+            var apiHeaders = new Dictionary<string, string>()
+            {
+                { "content-type", "application/json" }
+            };
+
+
+            static Models.Project Convert(Dictionary<string, object> it)
+            {
+                return Models.Project.From(map: it);
+            }
+
+            return _client.Call<Models.Project>(
+                method: "PATCH",
+                path: apiPath,
+                headers: apiHeaders,
+                parameters: apiParameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!,
+                convert: Convert);
+
+        }
+
+        /// <para>
         /// Get a list of all project environment variables.
         /// </para>
         /// </summary>
@@ -33,8 +766,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.VariableList Convert(Dictionary<string, object> it) =>
-                Models.VariableList.From(map: it);
+            static Models.VariableList Convert(Dictionary<string, object> it)
+            {
+                return Models.VariableList.From(map: it);
+            }
 
             return _client.Call<Models.VariableList>(
                 method: "GET",
@@ -68,8 +803,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "POST",
@@ -98,8 +835,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "GET",
@@ -132,8 +871,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "PUT",

--- a/Appwrite/Services/Project.cs
+++ b/Appwrite/Services/Project.cs
@@ -636,7 +636,27 @@ namespace Appwrite.Services
 
             static object Convert(Dictionary<string, object> it)
             {
-                return Appwrite.Models.PlatformWeb.From(map: it);
+                if (it.TryGetValue("type", out var typeValue1) && typeValue1?.ToString() == "web")
+                {
+                    return Appwrite.Models.PlatformWeb.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue2) && typeValue2?.ToString() == "apple")
+                {
+                    return Appwrite.Models.PlatformApple.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue3) && typeValue3?.ToString() == "android")
+                {
+                    return Appwrite.Models.PlatformAndroid.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue4) && typeValue4?.ToString() == "windows")
+                {
+                    return Appwrite.Models.PlatformWindows.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue5) && typeValue5?.ToString() == "linux")
+                {
+                    return Appwrite.Models.PlatformLinux.From(map: it);
+                }
+                throw new System.Exception("Unable to match response to any expected response model");
             }
 
             return _client.Call<object>(

--- a/Appwrite/Services/Sites.cs
+++ b/Appwrite/Services/Sites.cs
@@ -35,8 +35,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.SiteList Convert(Dictionary<string, object> it) =>
-                Models.SiteList.From(map: it);
+            static Models.SiteList Convert(Dictionary<string, object> it)
+            {
+                return Models.SiteList.From(map: it);
+            }
 
             return _client.Call<Models.SiteList>(
                 method: "GET",
@@ -86,8 +88,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Site Convert(Dictionary<string, object> it) =>
-                Models.Site.From(map: it);
+            static Models.Site Convert(Dictionary<string, object> it)
+            {
+                return Models.Site.From(map: it);
+            }
 
             return _client.Call<Models.Site>(
                 method: "POST",
@@ -116,8 +120,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.FrameworkList Convert(Dictionary<string, object> it) =>
-                Models.FrameworkList.From(map: it);
+            static Models.FrameworkList Convert(Dictionary<string, object> it)
+            {
+                return Models.FrameworkList.From(map: it);
+            }
 
             return _client.Call<Models.FrameworkList>(
                 method: "GET",
@@ -145,8 +151,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.SpecificationList Convert(Dictionary<string, object> it) =>
-                Models.SpecificationList.From(map: it);
+            static Models.SpecificationList Convert(Dictionary<string, object> it)
+            {
+                return Models.SpecificationList.From(map: it);
+            }
 
             return _client.Call<Models.SpecificationList>(
                 method: "GET",
@@ -175,8 +183,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Site Convert(Dictionary<string, object> it) =>
-                Models.Site.From(map: it);
+            static Models.Site Convert(Dictionary<string, object> it)
+            {
+                return Models.Site.From(map: it);
+            }
 
             return _client.Call<Models.Site>(
                 method: "GET",
@@ -226,8 +236,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Site Convert(Dictionary<string, object> it) =>
-                Models.Site.From(map: it);
+            static Models.Site Convert(Dictionary<string, object> it)
+            {
+                return Models.Site.From(map: it);
+            }
 
             return _client.Call<Models.Site>(
                 method: "PUT",
@@ -287,8 +299,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Site Convert(Dictionary<string, object> it) =>
-                Models.Site.From(map: it);
+            static Models.Site Convert(Dictionary<string, object> it)
+            {
+                return Models.Site.From(map: it);
+            }
 
             return _client.Call<Models.Site>(
                 method: "PATCH",
@@ -321,8 +335,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DeploymentList Convert(Dictionary<string, object> it) =>
-                Models.DeploymentList.From(map: it);
+            static Models.DeploymentList Convert(Dictionary<string, object> it)
+            {
+                return Models.DeploymentList.From(map: it);
+            }
 
             return _client.Call<Models.DeploymentList>(
                 method: "GET",
@@ -359,8 +375,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             string? idParamName = null;
 
@@ -400,8 +418,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "POST",
@@ -441,8 +461,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "POST",
@@ -477,8 +499,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "POST",
@@ -508,8 +532,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "GET",
@@ -604,8 +630,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Deployment Convert(Dictionary<string, object> it) =>
-                Models.Deployment.From(map: it);
+            static Models.Deployment Convert(Dictionary<string, object> it)
+            {
+                return Models.Deployment.From(map: it);
+            }
 
             return _client.Call<Models.Deployment>(
                 method: "PATCH",
@@ -637,8 +665,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ExecutionList Convert(Dictionary<string, object> it) =>
-                Models.ExecutionList.From(map: it);
+            static Models.ExecutionList Convert(Dictionary<string, object> it)
+            {
+                return Models.ExecutionList.From(map: it);
+            }
 
             return _client.Call<Models.ExecutionList>(
                 method: "GET",
@@ -668,8 +698,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Execution Convert(Dictionary<string, object> it) =>
-                Models.Execution.From(map: it);
+            static Models.Execution Convert(Dictionary<string, object> it)
+            {
+                return Models.Execution.From(map: it);
+            }
 
             return _client.Call<Models.Execution>(
                 method: "GET",
@@ -727,8 +759,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.VariableList Convert(Dictionary<string, object> it) =>
-                Models.VariableList.From(map: it);
+            static Models.VariableList Convert(Dictionary<string, object> it)
+            {
+                return Models.VariableList.From(map: it);
+            }
 
             return _client.Call<Models.VariableList>(
                 method: "GET",
@@ -762,8 +796,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "POST",
@@ -793,8 +829,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "GET",
@@ -828,8 +866,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Variable Convert(Dictionary<string, object> it) =>
-                Models.Variable.From(map: it);
+            static Models.Variable Convert(Dictionary<string, object> it)
+            {
+                return Models.Variable.From(map: it);
+            }
 
             return _client.Call<Models.Variable>(
                 method: "PUT",

--- a/Appwrite/Services/Storage.cs
+++ b/Appwrite/Services/Storage.cs
@@ -35,8 +35,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.BucketList Convert(Dictionary<string, object> it) =>
-                Models.BucketList.From(map: it);
+            static Models.BucketList Convert(Dictionary<string, object> it)
+            {
+                return Models.BucketList.From(map: it);
+            }
 
             return _client.Call<Models.BucketList>(
                 method: "GET",
@@ -76,8 +78,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Bucket Convert(Dictionary<string, object> it) =>
-                Models.Bucket.From(map: it);
+            static Models.Bucket Convert(Dictionary<string, object> it)
+            {
+                return Models.Bucket.From(map: it);
+            }
 
             return _client.Call<Models.Bucket>(
                 method: "POST",
@@ -107,8 +111,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Bucket Convert(Dictionary<string, object> it) =>
-                Models.Bucket.From(map: it);
+            static Models.Bucket Convert(Dictionary<string, object> it)
+            {
+                return Models.Bucket.From(map: it);
+            }
 
             return _client.Call<Models.Bucket>(
                 method: "GET",
@@ -148,8 +154,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Bucket Convert(Dictionary<string, object> it) =>
-                Models.Bucket.From(map: it);
+            static Models.Bucket Convert(Dictionary<string, object> it)
+            {
+                return Models.Bucket.From(map: it);
+            }
 
             return _client.Call<Models.Bucket>(
                 method: "PUT",
@@ -210,8 +218,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.FileList Convert(Dictionary<string, object> it) =>
-                Models.FileList.From(map: it);
+            static Models.FileList Convert(Dictionary<string, object> it)
+            {
+                return Models.FileList.From(map: it);
+            }
 
             return _client.Call<Models.FileList>(
                 method: "GET",
@@ -261,8 +271,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.File Convert(Dictionary<string, object> it) =>
-                Models.File.From(map: it);
+            static Models.File Convert(Dictionary<string, object> it)
+            {
+                return Models.File.From(map: it);
+            }
 
             string? idParamName = "fileId";
 
@@ -298,8 +310,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.File Convert(Dictionary<string, object> it) =>
-                Models.File.From(map: it);
+            static Models.File Convert(Dictionary<string, object> it)
+            {
+                return Models.File.From(map: it);
+            }
 
             return _client.Call<Models.File>(
                 method: "GET",
@@ -333,8 +347,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.File Convert(Dictionary<string, object> it) =>
-                Models.File.From(map: it);
+            static Models.File Convert(Dictionary<string, object> it)
+            {
+                return Models.File.From(map: it);
+            }
 
             return _client.Call<Models.File>(
                 method: "PUT",

--- a/Appwrite/Services/TablesDB.cs
+++ b/Appwrite/Services/TablesDB.cs
@@ -35,8 +35,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.DatabaseList Convert(Dictionary<string, object> it) =>
-                Models.DatabaseList.From(map: it);
+            static Models.DatabaseList Convert(Dictionary<string, object> it)
+            {
+                return Models.DatabaseList.From(map: it);
+            }
 
             return _client.Call<Models.DatabaseList>(
                 method: "GET",
@@ -69,8 +71,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Database Convert(Dictionary<string, object> it) =>
-                Models.Database.From(map: it);
+            static Models.Database Convert(Dictionary<string, object> it)
+            {
+                return Models.Database.From(map: it);
+            }
 
             return _client.Call<Models.Database>(
                 method: "POST",
@@ -99,8 +103,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.TransactionList Convert(Dictionary<string, object> it) =>
-                Models.TransactionList.From(map: it);
+            static Models.TransactionList Convert(Dictionary<string, object> it)
+            {
+                return Models.TransactionList.From(map: it);
+            }
 
             return _client.Call<Models.TransactionList>(
                 method: "GET",
@@ -130,8 +136,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Transaction Convert(Dictionary<string, object> it) =>
-                Models.Transaction.From(map: it);
+            static Models.Transaction Convert(Dictionary<string, object> it)
+            {
+                return Models.Transaction.From(map: it);
+            }
 
             return _client.Call<Models.Transaction>(
                 method: "POST",
@@ -160,8 +168,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Transaction Convert(Dictionary<string, object> it) =>
-                Models.Transaction.From(map: it);
+            static Models.Transaction Convert(Dictionary<string, object> it)
+            {
+                return Models.Transaction.From(map: it);
+            }
 
             return _client.Call<Models.Transaction>(
                 method: "GET",
@@ -193,8 +203,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Transaction Convert(Dictionary<string, object> it) =>
-                Models.Transaction.From(map: it);
+            static Models.Transaction Convert(Dictionary<string, object> it)
+            {
+                return Models.Transaction.From(map: it);
+            }
 
             return _client.Call<Models.Transaction>(
                 method: "PATCH",
@@ -253,8 +265,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Transaction Convert(Dictionary<string, object> it) =>
-                Models.Transaction.From(map: it);
+            static Models.Transaction Convert(Dictionary<string, object> it)
+            {
+                return Models.Transaction.From(map: it);
+            }
 
             return _client.Call<Models.Transaction>(
                 method: "POST",
@@ -284,8 +298,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Database Convert(Dictionary<string, object> it) =>
-                Models.Database.From(map: it);
+            static Models.Database Convert(Dictionary<string, object> it)
+            {
+                return Models.Database.From(map: it);
+            }
 
             return _client.Call<Models.Database>(
                 method: "GET",
@@ -317,8 +333,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Database Convert(Dictionary<string, object> it) =>
-                Models.Database.From(map: it);
+            static Models.Database Convert(Dictionary<string, object> it)
+            {
+                return Models.Database.From(map: it);
+            }
 
             return _client.Call<Models.Database>(
                 method: "PUT",
@@ -380,8 +398,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.TableList Convert(Dictionary<string, object> it) =>
-                Models.TableList.From(map: it);
+            static Models.TableList Convert(Dictionary<string, object> it)
+            {
+                return Models.TableList.From(map: it);
+            }
 
             return _client.Call<Models.TableList>(
                 method: "GET",
@@ -421,8 +441,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Table Convert(Dictionary<string, object> it) =>
-                Models.Table.From(map: it);
+            static Models.Table Convert(Dictionary<string, object> it)
+            {
+                return Models.Table.From(map: it);
+            }
 
             return _client.Call<Models.Table>(
                 method: "POST",
@@ -453,8 +475,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Table Convert(Dictionary<string, object> it) =>
-                Models.Table.From(map: it);
+            static Models.Table Convert(Dictionary<string, object> it)
+            {
+                return Models.Table.From(map: it);
+            }
 
             return _client.Call<Models.Table>(
                 method: "GET",
@@ -469,7 +493,7 @@ namespace Appwrite.Services
         /// Update a table by its unique ID.
         /// </para>
         /// </summary>
-        public Task<Models.Table> UpdateTable(string databaseId, string tableId, string? name = null, List<string>? permissions = null, bool? rowSecurity = null, bool? enabled = null)
+        public Task<Models.Table> UpdateTable(string databaseId, string tableId, string? name = null, List<string>? permissions = null, bool? rowSecurity = null, bool? enabled = null, bool? purge = null)
         {
             var apiPath = "/tablesdb/{databaseId}/tables/{tableId}"
                 .Replace("{databaseId}", databaseId)
@@ -480,7 +504,8 @@ namespace Appwrite.Services
                 { "name", name },
                 { "permissions", permissions },
                 { "rowSecurity", rowSecurity },
-                { "enabled", enabled }
+                { "enabled", enabled },
+                { "purge", purge }
             };
 
             var apiHeaders = new Dictionary<string, string>()
@@ -489,8 +514,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Table Convert(Dictionary<string, object> it) =>
-                Models.Table.From(map: it);
+            static Models.Table Convert(Dictionary<string, object> it)
+            {
+                return Models.Table.From(map: it);
+            }
 
             return _client.Call<Models.Table>(
                 method: "PUT",
@@ -552,8 +579,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnList Convert(Dictionary<string, object> it) =>
-                Models.ColumnList.From(map: it);
+            static Models.ColumnList Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnList.From(map: it);
+            }
 
             return _client.Call<Models.ColumnList>(
                 method: "GET",
@@ -589,8 +618,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnBoolean Convert(Dictionary<string, object> it) =>
-                Models.ColumnBoolean.From(map: it);
+            static Models.ColumnBoolean Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnBoolean.From(map: it);
+            }
 
             return _client.Call<Models.ColumnBoolean>(
                 method: "POST",
@@ -626,8 +657,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnBoolean Convert(Dictionary<string, object> it) =>
-                Models.ColumnBoolean.From(map: it);
+            static Models.ColumnBoolean Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnBoolean.From(map: it);
+            }
 
             return _client.Call<Models.ColumnBoolean>(
                 method: "PATCH",
@@ -662,8 +695,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnDatetime Convert(Dictionary<string, object> it) =>
-                Models.ColumnDatetime.From(map: it);
+            static Models.ColumnDatetime Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnDatetime.From(map: it);
+            }
 
             return _client.Call<Models.ColumnDatetime>(
                 method: "POST",
@@ -699,8 +734,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnDatetime Convert(Dictionary<string, object> it) =>
-                Models.ColumnDatetime.From(map: it);
+            static Models.ColumnDatetime Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnDatetime.From(map: it);
+            }
 
             return _client.Call<Models.ColumnDatetime>(
                 method: "PATCH",
@@ -736,8 +773,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnEmail Convert(Dictionary<string, object> it) =>
-                Models.ColumnEmail.From(map: it);
+            static Models.ColumnEmail Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnEmail.From(map: it);
+            }
 
             return _client.Call<Models.ColumnEmail>(
                 method: "POST",
@@ -774,8 +813,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnEmail Convert(Dictionary<string, object> it) =>
-                Models.ColumnEmail.From(map: it);
+            static Models.ColumnEmail Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnEmail.From(map: it);
+            }
 
             return _client.Call<Models.ColumnEmail>(
                 method: "PATCH",
@@ -812,8 +853,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnEnum Convert(Dictionary<string, object> it) =>
-                Models.ColumnEnum.From(map: it);
+            static Models.ColumnEnum Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnEnum.From(map: it);
+            }
 
             return _client.Call<Models.ColumnEnum>(
                 method: "POST",
@@ -851,8 +894,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnEnum Convert(Dictionary<string, object> it) =>
-                Models.ColumnEnum.From(map: it);
+            static Models.ColumnEnum Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnEnum.From(map: it);
+            }
 
             return _client.Call<Models.ColumnEnum>(
                 method: "PATCH",
@@ -891,8 +936,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnFloat Convert(Dictionary<string, object> it) =>
-                Models.ColumnFloat.From(map: it);
+            static Models.ColumnFloat Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnFloat.From(map: it);
+            }
 
             return _client.Call<Models.ColumnFloat>(
                 method: "POST",
@@ -931,8 +978,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnFloat Convert(Dictionary<string, object> it) =>
-                Models.ColumnFloat.From(map: it);
+            static Models.ColumnFloat Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnFloat.From(map: it);
+            }
 
             return _client.Call<Models.ColumnFloat>(
                 method: "PATCH",
@@ -971,8 +1020,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnInteger Convert(Dictionary<string, object> it) =>
-                Models.ColumnInteger.From(map: it);
+            static Models.ColumnInteger Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnInteger.From(map: it);
+            }
 
             return _client.Call<Models.ColumnInteger>(
                 method: "POST",
@@ -1011,8 +1062,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnInteger Convert(Dictionary<string, object> it) =>
-                Models.ColumnInteger.From(map: it);
+            static Models.ColumnInteger Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnInteger.From(map: it);
+            }
 
             return _client.Call<Models.ColumnInteger>(
                 method: "PATCH",
@@ -1048,8 +1101,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnIp Convert(Dictionary<string, object> it) =>
-                Models.ColumnIp.From(map: it);
+            static Models.ColumnIp Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnIp.From(map: it);
+            }
 
             return _client.Call<Models.ColumnIp>(
                 method: "POST",
@@ -1086,8 +1141,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnIp Convert(Dictionary<string, object> it) =>
-                Models.ColumnIp.From(map: it);
+            static Models.ColumnIp Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnIp.From(map: it);
+            }
 
             return _client.Call<Models.ColumnIp>(
                 method: "PATCH",
@@ -1121,8 +1178,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnLine Convert(Dictionary<string, object> it) =>
-                Models.ColumnLine.From(map: it);
+            static Models.ColumnLine Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnLine.From(map: it);
+            }
 
             return _client.Call<Models.ColumnLine>(
                 method: "POST",
@@ -1158,8 +1217,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnLine Convert(Dictionary<string, object> it) =>
-                Models.ColumnLine.From(map: it);
+            static Models.ColumnLine Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnLine.From(map: it);
+            }
 
             return _client.Call<Models.ColumnLine>(
                 method: "PATCH",
@@ -1196,8 +1257,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnLongtext Convert(Dictionary<string, object> it) =>
-                Models.ColumnLongtext.From(map: it);
+            static Models.ColumnLongtext Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnLongtext.From(map: it);
+            }
 
             return _client.Call<Models.ColumnLongtext>(
                 method: "POST",
@@ -1234,8 +1297,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnLongtext Convert(Dictionary<string, object> it) =>
-                Models.ColumnLongtext.From(map: it);
+            static Models.ColumnLongtext Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnLongtext.From(map: it);
+            }
 
             return _client.Call<Models.ColumnLongtext>(
                 method: "PATCH",
@@ -1272,8 +1337,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnMediumtext Convert(Dictionary<string, object> it) =>
-                Models.ColumnMediumtext.From(map: it);
+            static Models.ColumnMediumtext Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnMediumtext.From(map: it);
+            }
 
             return _client.Call<Models.ColumnMediumtext>(
                 method: "POST",
@@ -1310,8 +1377,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnMediumtext Convert(Dictionary<string, object> it) =>
-                Models.ColumnMediumtext.From(map: it);
+            static Models.ColumnMediumtext Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnMediumtext.From(map: it);
+            }
 
             return _client.Call<Models.ColumnMediumtext>(
                 method: "PATCH",
@@ -1345,8 +1414,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnPoint Convert(Dictionary<string, object> it) =>
-                Models.ColumnPoint.From(map: it);
+            static Models.ColumnPoint Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnPoint.From(map: it);
+            }
 
             return _client.Call<Models.ColumnPoint>(
                 method: "POST",
@@ -1382,8 +1453,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnPoint Convert(Dictionary<string, object> it) =>
-                Models.ColumnPoint.From(map: it);
+            static Models.ColumnPoint Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnPoint.From(map: it);
+            }
 
             return _client.Call<Models.ColumnPoint>(
                 method: "PATCH",
@@ -1417,8 +1490,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnPolygon Convert(Dictionary<string, object> it) =>
-                Models.ColumnPolygon.From(map: it);
+            static Models.ColumnPolygon Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnPolygon.From(map: it);
+            }
 
             return _client.Call<Models.ColumnPolygon>(
                 method: "POST",
@@ -1454,8 +1529,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnPolygon Convert(Dictionary<string, object> it) =>
-                Models.ColumnPolygon.From(map: it);
+            static Models.ColumnPolygon Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnPolygon.From(map: it);
+            }
 
             return _client.Call<Models.ColumnPolygon>(
                 method: "PATCH",
@@ -1494,8 +1571,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnRelationship Convert(Dictionary<string, object> it) =>
-                Models.ColumnRelationship.From(map: it);
+            static Models.ColumnRelationship Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnRelationship.From(map: it);
+            }
 
             return _client.Call<Models.ColumnRelationship>(
                 method: "POST",
@@ -1534,8 +1613,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnString Convert(Dictionary<string, object> it) =>
-                Models.ColumnString.From(map: it);
+            static Models.ColumnString Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnString.From(map: it);
+            }
 
             return _client.Call<Models.ColumnString>(
                 method: "POST",
@@ -1574,8 +1655,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnString Convert(Dictionary<string, object> it) =>
-                Models.ColumnString.From(map: it);
+            static Models.ColumnString Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnString.From(map: it);
+            }
 
             return _client.Call<Models.ColumnString>(
                 method: "PATCH",
@@ -1612,8 +1695,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnText Convert(Dictionary<string, object> it) =>
-                Models.ColumnText.From(map: it);
+            static Models.ColumnText Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnText.From(map: it);
+            }
 
             return _client.Call<Models.ColumnText>(
                 method: "POST",
@@ -1650,8 +1735,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnText Convert(Dictionary<string, object> it) =>
-                Models.ColumnText.From(map: it);
+            static Models.ColumnText Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnText.From(map: it);
+            }
 
             return _client.Call<Models.ColumnText>(
                 method: "PATCH",
@@ -1687,8 +1774,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnUrl Convert(Dictionary<string, object> it) =>
-                Models.ColumnUrl.From(map: it);
+            static Models.ColumnUrl Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnUrl.From(map: it);
+            }
 
             return _client.Call<Models.ColumnUrl>(
                 method: "POST",
@@ -1725,8 +1814,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnUrl Convert(Dictionary<string, object> it) =>
-                Models.ColumnUrl.From(map: it);
+            static Models.ColumnUrl Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnUrl.From(map: it);
+            }
 
             return _client.Call<Models.ColumnUrl>(
                 method: "PATCH",
@@ -1764,8 +1855,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnVarchar Convert(Dictionary<string, object> it) =>
-                Models.ColumnVarchar.From(map: it);
+            static Models.ColumnVarchar Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnVarchar.From(map: it);
+            }
 
             return _client.Call<Models.ColumnVarchar>(
                 method: "POST",
@@ -1803,8 +1896,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnVarchar Convert(Dictionary<string, object> it) =>
-                Models.ColumnVarchar.From(map: it);
+            static Models.ColumnVarchar Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnVarchar.From(map: it);
+            }
 
             return _client.Call<Models.ColumnVarchar>(
                 method: "PATCH",
@@ -1835,8 +1930,10 @@ namespace Appwrite.Services
             };
 
 
-            static object Convert(Dictionary<string, object> it) =>
-                it;
+            static object Convert(Dictionary<string, object> it)
+            {
+                return Appwrite.Models.ColumnBoolean.From(map: it);
+            }
 
             return _client.Call<object>(
                 method: "GET",
@@ -1902,8 +1999,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnRelationship Convert(Dictionary<string, object> it) =>
-                Models.ColumnRelationship.From(map: it);
+            static Models.ColumnRelationship Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnRelationship.From(map: it);
+            }
 
             return _client.Call<Models.ColumnRelationship>(
                 method: "PATCH",
@@ -1935,8 +2034,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnIndexList Convert(Dictionary<string, object> it) =>
-                Models.ColumnIndexList.From(map: it);
+            static Models.ColumnIndexList Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnIndexList.From(map: it);
+            }
 
             return _client.Call<Models.ColumnIndexList>(
                 method: "GET",
@@ -1974,8 +2075,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnIndex Convert(Dictionary<string, object> it) =>
-                Models.ColumnIndex.From(map: it);
+            static Models.ColumnIndex Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnIndex.From(map: it);
+            }
 
             return _client.Call<Models.ColumnIndex>(
                 method: "POST",
@@ -2006,8 +2109,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ColumnIndex Convert(Dictionary<string, object> it) =>
-                Models.ColumnIndex.From(map: it);
+            static Models.ColumnIndex Convert(Dictionary<string, object> it)
+            {
+                return Models.ColumnIndex.From(map: it);
+            }
 
             return _client.Call<Models.ColumnIndex>(
                 method: "GET",
@@ -2072,8 +2177,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.RowList Convert(Dictionary<string, object> it) =>
-                Models.RowList.From(map: it);
+            static Models.RowList Convert(Dictionary<string, object> it)
+            {
+                return Models.RowList.From(map: it);
+            }
 
             return _client.Call<Models.RowList>(
                 method: "GET",
@@ -2111,8 +2218,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Row Convert(Dictionary<string, object> it) =>
-                Models.Row.From(map: it);
+            static Models.Row Convert(Dictionary<string, object> it)
+            {
+                return Models.Row.From(map: it);
+            }
 
             return _client.Call<Models.Row>(
                 method: "POST",
@@ -2148,8 +2257,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.RowList Convert(Dictionary<string, object> it) =>
-                Models.RowList.From(map: it);
+            static Models.RowList Convert(Dictionary<string, object> it)
+            {
+                return Models.RowList.From(map: it);
+            }
 
             return _client.Call<Models.RowList>(
                 method: "POST",
@@ -2186,8 +2297,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.RowList Convert(Dictionary<string, object> it) =>
-                Models.RowList.From(map: it);
+            static Models.RowList Convert(Dictionary<string, object> it)
+            {
+                return Models.RowList.From(map: it);
+            }
 
             return _client.Call<Models.RowList>(
                 method: "PUT",
@@ -2222,8 +2335,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.RowList Convert(Dictionary<string, object> it) =>
-                Models.RowList.From(map: it);
+            static Models.RowList Convert(Dictionary<string, object> it)
+            {
+                return Models.RowList.From(map: it);
+            }
 
             return _client.Call<Models.RowList>(
                 method: "PATCH",
@@ -2257,8 +2372,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.RowList Convert(Dictionary<string, object> it) =>
-                Models.RowList.From(map: it);
+            static Models.RowList Convert(Dictionary<string, object> it)
+            {
+                return Models.RowList.From(map: it);
+            }
 
             return _client.Call<Models.RowList>(
                 method: "DELETE",
@@ -2292,8 +2409,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Row Convert(Dictionary<string, object> it) =>
-                Models.Row.From(map: it);
+            static Models.Row Convert(Dictionary<string, object> it)
+            {
+                return Models.Row.From(map: it);
+            }
 
             return _client.Call<Models.Row>(
                 method: "GET",
@@ -2331,8 +2450,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Row Convert(Dictionary<string, object> it) =>
-                Models.Row.From(map: it);
+            static Models.Row Convert(Dictionary<string, object> it)
+            {
+                return Models.Row.From(map: it);
+            }
 
             return _client.Call<Models.Row>(
                 method: "PUT",
@@ -2368,8 +2489,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Row Convert(Dictionary<string, object> it) =>
-                Models.Row.From(map: it);
+            static Models.Row Convert(Dictionary<string, object> it)
+            {
+                return Models.Row.From(map: it);
+            }
 
             return _client.Call<Models.Row>(
                 method: "PATCH",
@@ -2436,8 +2559,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Row Convert(Dictionary<string, object> it) =>
-                Models.Row.From(map: it);
+            static Models.Row Convert(Dictionary<string, object> it)
+            {
+                return Models.Row.From(map: it);
+            }
 
             return _client.Call<Models.Row>(
                 method: "PATCH",
@@ -2473,8 +2598,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Row Convert(Dictionary<string, object> it) =>
-                Models.Row.From(map: it);
+            static Models.Row Convert(Dictionary<string, object> it)
+            {
+                return Models.Row.From(map: it);
+            }
 
             return _client.Call<Models.Row>(
                 method: "PATCH",

--- a/Appwrite/Services/TablesDB.cs
+++ b/Appwrite/Services/TablesDB.cs
@@ -1932,7 +1932,47 @@ namespace Appwrite.Services
 
             static object Convert(Dictionary<string, object> it)
             {
-                return Appwrite.Models.ColumnBoolean.From(map: it);
+                if (it.TryGetValue("type", out var typeValue1) && typeValue1?.ToString() == "string" && it.TryGetValue("format", out var formatValue1) && formatValue1?.ToString() == "email")
+                {
+                    return Appwrite.Models.ColumnEmail.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue2) && typeValue2?.ToString() == "string" && it.TryGetValue("format", out var formatValue2) && formatValue2?.ToString() == "enum")
+                {
+                    return Appwrite.Models.ColumnEnum.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue3) && typeValue3?.ToString() == "string" && it.TryGetValue("format", out var formatValue3) && formatValue3?.ToString() == "url")
+                {
+                    return Appwrite.Models.ColumnUrl.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue4) && typeValue4?.ToString() == "string" && it.TryGetValue("format", out var formatValue4) && formatValue4?.ToString() == "ip")
+                {
+                    return Appwrite.Models.ColumnIp.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue5) && typeValue5?.ToString() == "boolean")
+                {
+                    return Appwrite.Models.ColumnBoolean.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue6) && typeValue6?.ToString() == "integer")
+                {
+                    return Appwrite.Models.ColumnInteger.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue7) && typeValue7?.ToString() == "double")
+                {
+                    return Appwrite.Models.ColumnFloat.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue8) && typeValue8?.ToString() == "datetime")
+                {
+                    return Appwrite.Models.ColumnDatetime.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue9) && typeValue9?.ToString() == "relationship")
+                {
+                    return Appwrite.Models.ColumnRelationship.From(map: it);
+                }
+                if (it.TryGetValue("type", out var typeValue10) && typeValue10?.ToString() == "string")
+                {
+                    return Appwrite.Models.ColumnString.From(map: it);
+                }
+                throw new System.Exception("Unable to match response to any expected response model");
             }
 
             return _client.Call<object>(

--- a/Appwrite/Services/Teams.cs
+++ b/Appwrite/Services/Teams.cs
@@ -35,8 +35,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.TeamList Convert(Dictionary<string, object> it) =>
-                Models.TeamList.From(map: it);
+            static Models.TeamList Convert(Dictionary<string, object> it)
+            {
+                return Models.TeamList.From(map: it);
+            }
 
             return _client.Call<Models.TeamList>(
                 method: "GET",
@@ -70,8 +72,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Team Convert(Dictionary<string, object> it) =>
-                Models.Team.From(map: it);
+            static Models.Team Convert(Dictionary<string, object> it)
+            {
+                return Models.Team.From(map: it);
+            }
 
             return _client.Call<Models.Team>(
                 method: "POST",
@@ -100,8 +104,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Team Convert(Dictionary<string, object> it) =>
-                Models.Team.From(map: it);
+            static Models.Team Convert(Dictionary<string, object> it)
+            {
+                return Models.Team.From(map: it);
+            }
 
             return _client.Call<Models.Team>(
                 method: "GET",
@@ -132,8 +138,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Team Convert(Dictionary<string, object> it) =>
-                Models.Team.From(map: it);
+            static Models.Team Convert(Dictionary<string, object> it)
+            {
+                return Models.Team.From(map: it);
+            }
 
             return _client.Call<Models.Team>(
                 method: "PUT",
@@ -196,8 +204,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MembershipList Convert(Dictionary<string, object> it) =>
-                Models.MembershipList.From(map: it);
+            static Models.MembershipList Convert(Dictionary<string, object> it)
+            {
+                return Models.MembershipList.From(map: it);
+            }
 
             return _client.Call<Models.MembershipList>(
                 method: "GET",
@@ -253,8 +263,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Membership Convert(Dictionary<string, object> it) =>
-                Models.Membership.From(map: it);
+            static Models.Membership Convert(Dictionary<string, object> it)
+            {
+                return Models.Membership.From(map: it);
+            }
 
             return _client.Call<Models.Membership>(
                 method: "POST",
@@ -286,8 +298,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Membership Convert(Dictionary<string, object> it) =>
-                Models.Membership.From(map: it);
+            static Models.Membership Convert(Dictionary<string, object> it)
+            {
+                return Models.Membership.From(map: it);
+            }
 
             return _client.Call<Models.Membership>(
                 method: "GET",
@@ -322,8 +336,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Membership Convert(Dictionary<string, object> it) =>
-                Models.Membership.From(map: it);
+            static Models.Membership Convert(Dictionary<string, object> it)
+            {
+                return Models.Membership.From(map: it);
+            }
 
             return _client.Call<Models.Membership>(
                 method: "PATCH",
@@ -393,8 +409,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Membership Convert(Dictionary<string, object> it) =>
-                Models.Membership.From(map: it);
+            static Models.Membership Convert(Dictionary<string, object> it)
+            {
+                return Models.Membership.From(map: it);
+            }
 
             return _client.Call<Models.Membership>(
                 method: "PATCH",
@@ -425,8 +443,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Preferences Convert(Dictionary<string, object> it) =>
-                Models.Preferences.From(map: it);
+            static Models.Preferences Convert(Dictionary<string, object> it)
+            {
+                return Models.Preferences.From(map: it);
+            }
 
             return _client.Call<Models.Preferences>(
                 method: "GET",
@@ -459,8 +479,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Preferences Convert(Dictionary<string, object> it) =>
-                Models.Preferences.From(map: it);
+            static Models.Preferences Convert(Dictionary<string, object> it)
+            {
+                return Models.Preferences.From(map: it);
+            }
 
             return _client.Call<Models.Preferences>(
                 method: "PUT",

--- a/Appwrite/Services/Tokens.cs
+++ b/Appwrite/Services/Tokens.cs
@@ -36,8 +36,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ResourceTokenList Convert(Dictionary<string, object> it) =>
-                Models.ResourceTokenList.From(map: it);
+            static Models.ResourceTokenList Convert(Dictionary<string, object> it)
+            {
+                return Models.ResourceTokenList.From(map: it);
+            }
 
             return _client.Call<Models.ResourceTokenList>(
                 method: "GET",
@@ -70,8 +72,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ResourceToken Convert(Dictionary<string, object> it) =>
-                Models.ResourceToken.From(map: it);
+            static Models.ResourceToken Convert(Dictionary<string, object> it)
+            {
+                return Models.ResourceToken.From(map: it);
+            }
 
             return _client.Call<Models.ResourceToken>(
                 method: "POST",
@@ -100,8 +104,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ResourceToken Convert(Dictionary<string, object> it) =>
-                Models.ResourceToken.From(map: it);
+            static Models.ResourceToken Convert(Dictionary<string, object> it)
+            {
+                return Models.ResourceToken.From(map: it);
+            }
 
             return _client.Call<Models.ResourceToken>(
                 method: "GET",
@@ -133,8 +139,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.ResourceToken Convert(Dictionary<string, object> it) =>
-                Models.ResourceToken.From(map: it);
+            static Models.ResourceToken Convert(Dictionary<string, object> it)
+            {
+                return Models.ResourceToken.From(map: it);
+            }
 
             return _client.Call<Models.ResourceToken>(
                 method: "PATCH",

--- a/Appwrite/Services/Users.cs
+++ b/Appwrite/Services/Users.cs
@@ -35,8 +35,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.UserList Convert(Dictionary<string, object> it) =>
-                Models.UserList.From(map: it);
+            static Models.UserList Convert(Dictionary<string, object> it)
+            {
+                return Models.UserList.From(map: it);
+            }
 
             return _client.Call<Models.UserList>(
                 method: "GET",
@@ -70,8 +72,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -107,8 +111,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -144,8 +150,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -176,8 +184,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.IdentityList Convert(Dictionary<string, object> it) =>
-                Models.IdentityList.From(map: it);
+            static Models.IdentityList Convert(Dictionary<string, object> it)
+            {
+                return Models.IdentityList.From(map: it);
+            }
 
             return _client.Call<Models.IdentityList>(
                 method: "GET",
@@ -241,8 +251,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -278,8 +290,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -320,8 +334,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -361,8 +377,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -399,8 +417,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "POST",
@@ -429,8 +449,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "GET",
@@ -494,8 +516,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -531,8 +555,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -566,8 +592,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.JWT Convert(Dictionary<string, object> it) =>
-                Models.JWT.From(map: it);
+            static Models.JWT Convert(Dictionary<string, object> it)
+            {
+                return Models.JWT.From(map: it);
+            }
 
             return _client.Call<Models.JWT>(
                 method: "POST",
@@ -603,8 +631,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PUT",
@@ -635,8 +665,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.LogList Convert(Dictionary<string, object> it) =>
-                Models.LogList.From(map: it);
+            static Models.LogList Convert(Dictionary<string, object> it)
+            {
+                return Models.LogList.From(map: it);
+            }
 
             return _client.Call<Models.LogList>(
                 method: "GET",
@@ -668,8 +700,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MembershipList Convert(Dictionary<string, object> it) =>
-                Models.MembershipList.From(map: it);
+            static Models.MembershipList Convert(Dictionary<string, object> it)
+            {
+                return Models.MembershipList.From(map: it);
+            }
 
             return _client.Call<Models.MembershipList>(
                 method: "GET",
@@ -701,8 +735,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -733,8 +769,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -823,8 +861,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaFactors Convert(Dictionary<string, object> it) =>
-                Models.MfaFactors.From(map: it);
+            static Models.MfaFactors Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaFactors.From(map: it);
+            }
 
             return _client.Call<Models.MfaFactors>(
                 method: "GET",
@@ -853,8 +893,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaFactors Convert(Dictionary<string, object> it) =>
-                Models.MfaFactors.From(map: it);
+            static Models.MfaFactors Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaFactors.From(map: it);
+            }
 
             return _client.Call<Models.MfaFactors>(
                 method: "GET",
@@ -887,8 +929,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "GET",
@@ -920,8 +964,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "GET",
@@ -955,8 +1001,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "PUT",
@@ -989,8 +1037,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "PUT",
@@ -1024,8 +1074,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "PATCH",
@@ -1058,8 +1110,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it) =>
-                Models.MfaRecoveryCodes.From(map: it);
+            static Models.MfaRecoveryCodes Convert(Dictionary<string, object> it)
+            {
+                return Models.MfaRecoveryCodes.From(map: it);
+            }
 
             return _client.Call<Models.MfaRecoveryCodes>(
                 method: "PATCH",
@@ -1090,8 +1144,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -1122,8 +1178,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -1154,8 +1212,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -1184,8 +1244,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Preferences Convert(Dictionary<string, object> it) =>
-                Models.Preferences.From(map: it);
+            static Models.Preferences Convert(Dictionary<string, object> it)
+            {
+                return Models.Preferences.From(map: it);
+            }
 
             return _client.Call<Models.Preferences>(
                 method: "GET",
@@ -1218,8 +1280,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Preferences Convert(Dictionary<string, object> it) =>
-                Models.Preferences.From(map: it);
+            static Models.Preferences Convert(Dictionary<string, object> it)
+            {
+                return Models.Preferences.From(map: it);
+            }
 
             return _client.Call<Models.Preferences>(
                 method: "PATCH",
@@ -1249,8 +1313,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.SessionList Convert(Dictionary<string, object> it) =>
-                Models.SessionList.From(map: it);
+            static Models.SessionList Convert(Dictionary<string, object> it)
+            {
+                return Models.SessionList.From(map: it);
+            }
 
             return _client.Call<Models.SessionList>(
                 method: "GET",
@@ -1285,8 +1351,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Session Convert(Dictionary<string, object> it) =>
-                Models.Session.From(map: it);
+            static Models.Session Convert(Dictionary<string, object> it)
+            {
+                return Models.Session.From(map: it);
+            }
 
             return _client.Call<Models.Session>(
                 method: "POST",
@@ -1375,8 +1443,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -1407,8 +1477,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.TargetList Convert(Dictionary<string, object> it) =>
-                Models.TargetList.From(map: it);
+            static Models.TargetList Convert(Dictionary<string, object> it)
+            {
+                return Models.TargetList.From(map: it);
+            }
 
             return _client.Call<Models.TargetList>(
                 method: "GET",
@@ -1443,8 +1515,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Target Convert(Dictionary<string, object> it) =>
-                Models.Target.From(map: it);
+            static Models.Target Convert(Dictionary<string, object> it)
+            {
+                return Models.Target.From(map: it);
+            }
 
             return _client.Call<Models.Target>(
                 method: "POST",
@@ -1474,8 +1548,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Target Convert(Dictionary<string, object> it) =>
-                Models.Target.From(map: it);
+            static Models.Target Convert(Dictionary<string, object> it)
+            {
+                return Models.Target.From(map: it);
+            }
 
             return _client.Call<Models.Target>(
                 method: "GET",
@@ -1509,8 +1585,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Target Convert(Dictionary<string, object> it) =>
-                Models.Target.From(map: it);
+            static Models.Target Convert(Dictionary<string, object> it)
+            {
+                return Models.Target.From(map: it);
+            }
 
             return _client.Call<Models.Target>(
                 method: "PATCH",
@@ -1575,8 +1653,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Token Convert(Dictionary<string, object> it) =>
-                Models.Token.From(map: it);
+            static Models.Token Convert(Dictionary<string, object> it)
+            {
+                return Models.Token.From(map: it);
+            }
 
             return _client.Call<Models.Token>(
                 method: "POST",
@@ -1607,8 +1687,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",
@@ -1639,8 +1721,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.User Convert(Dictionary<string, object> it) =>
-                Models.User.From(map: it);
+            static Models.User Convert(Dictionary<string, object> it)
+            {
+                return Models.User.From(map: it);
+            }
 
             return _client.Call<Models.User>(
                 method: "PATCH",

--- a/Appwrite/Services/Webhooks.cs
+++ b/Appwrite/Services/Webhooks.cs
@@ -34,8 +34,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.WebhookList Convert(Dictionary<string, object> it) =>
-                Models.WebhookList.From(map: it);
+            static Models.WebhookList Convert(Dictionary<string, object> it)
+            {
+                return Models.WebhookList.From(map: it);
+            }
 
             return _client.Call<Models.WebhookList>(
                 method: "GET",
@@ -51,7 +53,7 @@ namespace Appwrite.Services
         /// receive events from Appwrite when specific events occur.
         /// </para>
         /// </summary>
-        public Task<Models.Webhook> Create(string webhookId, string url, string name, List<string> events, bool? enabled = null, bool? security = null, string? httpUser = null, string? httpPass = null)
+        public Task<Models.Webhook> Create(string webhookId, string url, string name, List<string> events, bool? enabled = null, bool? tls = null, string? authUsername = null, string? authPassword = null, string? secret = null)
         {
             var apiPath = "/webhooks";
 
@@ -62,9 +64,10 @@ namespace Appwrite.Services
                 { "name", name },
                 { "events", events },
                 { "enabled", enabled },
-                { "security", security },
-                { "httpUser", httpUser },
-                { "httpPass", httpPass }
+                { "tls", tls },
+                { "authUsername", authUsername },
+                { "authPassword", authPassword },
+                { "secret", secret }
             };
 
             var apiHeaders = new Dictionary<string, string>()
@@ -73,8 +76,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Webhook Convert(Dictionary<string, object> it) =>
-                Models.Webhook.From(map: it);
+            static Models.Webhook Convert(Dictionary<string, object> it)
+            {
+                return Models.Webhook.From(map: it);
+            }
 
             return _client.Call<Models.Webhook>(
                 method: "POST",
@@ -104,8 +109,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Webhook Convert(Dictionary<string, object> it) =>
-                Models.Webhook.From(map: it);
+            static Models.Webhook Convert(Dictionary<string, object> it)
+            {
+                return Models.Webhook.From(map: it);
+            }
 
             return _client.Call<Models.Webhook>(
                 method: "GET",
@@ -121,7 +128,7 @@ namespace Appwrite.Services
         /// events, or status of an existing webhook.
         /// </para>
         /// </summary>
-        public Task<Models.Webhook> Update(string webhookId, string name, string url, List<string> events, bool? enabled = null, bool? security = null, string? httpUser = null, string? httpPass = null)
+        public Task<Models.Webhook> Update(string webhookId, string name, string url, List<string> events, bool? enabled = null, bool? tls = null, string? authUsername = null, string? authPassword = null)
         {
             var apiPath = "/webhooks/{webhookId}"
                 .Replace("{webhookId}", webhookId);
@@ -132,9 +139,9 @@ namespace Appwrite.Services
                 { "url", url },
                 { "events", events },
                 { "enabled", enabled },
-                { "security", security },
-                { "httpUser", httpUser },
-                { "httpPass", httpPass }
+                { "tls", tls },
+                { "authUsername", authUsername },
+                { "authPassword", authPassword }
             };
 
             var apiHeaders = new Dictionary<string, string>()
@@ -143,8 +150,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Webhook Convert(Dictionary<string, object> it) =>
-                Models.Webhook.From(map: it);
+            static Models.Webhook Convert(Dictionary<string, object> it)
+            {
+                return Models.Webhook.From(map: it);
+            }
 
             return _client.Call<Models.Webhook>(
                 method: "PUT",
@@ -185,18 +194,19 @@ namespace Appwrite.Services
         }
 
         /// <para>
-        /// Update the webhook signature key. This endpoint can be used to regenerate
-        /// the signature key used to sign and validate payload deliveries for a
-        /// specific webhook.
+        /// Update the webhook signing key. This endpoint can be used to regenerate the
+        /// signing key used to sign and validate payload deliveries for a specific
+        /// webhook.
         /// </para>
         /// </summary>
-        public Task<Models.Webhook> UpdateSignature(string webhookId)
+        public Task<Models.Webhook> UpdateSecret(string webhookId, string? secret = null)
         {
-            var apiPath = "/webhooks/{webhookId}/signature"
+            var apiPath = "/webhooks/{webhookId}/secret"
                 .Replace("{webhookId}", webhookId);
 
             var apiParameters = new Dictionary<string, object?>()
             {
+                { "secret", secret }
             };
 
             var apiHeaders = new Dictionary<string, string>()
@@ -205,8 +215,10 @@ namespace Appwrite.Services
             };
 
 
-            static Models.Webhook Convert(Dictionary<string, object> it) =>
-                Models.Webhook.From(map: it);
+            static Models.Webhook Convert(Dictionary<string, object> it)
+            {
+                return Models.Webhook.From(map: it);
+            }
 
             return _client.Call<Models.Webhook>(
                 method: "PATCH",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,17 @@
 
 * [BREAKING] Renamed Webhook model fields: `security` → `tls`, `httpUser` → `authUsername`, `httpPass` → `authPassword`, `signatureKey` → `secret`
 * [BREAKING] Renamed Webhook service parameters to match: `security` → `tls`, `httpUser` → `authUsername`, `httpPass` → `authPassword`
+* [BREAKING] Renamed `Webhooks.UpdateSignature()` to `Webhooks.UpdateSecret()` with new optional `secret` parameter
+* Added `Client.GetHeaders()` method to retrieve request headers
 * Added `secret` parameter to Webhook create and update methods
 * Added `x` OAuth provider to `OAuthProvider` enum
 * Added `userType` field to `Log` model
-* Added `purge` parameter to `updateCollection` and `updateTable` for cache invalidation
+* Added `purge` parameter to `UpdateCollection` and `UpdateTable` for cache invalidation
 * Added Project service: platform CRUD, key CRUD, protocol/service status management
-* Added new models: `Key`, `KeyList`, `PlatformAndroid`, `PlatformApple`, `PlatformLinux`, `PlatformList`, and others
+* Added new models: `Key`, `KeyList`, `Project`, `DevKey`, `MockNumber`, `AuthProvider`, `PlatformAndroid`, `PlatformApple`, `PlatformLinux`, `PlatformList`, `PlatformWeb`, `PlatformWindows`, `BillingLimits`, `Block`
 * Added new enums: `PlatformType`, `ProtocolId`, `ServiceId`
-* Updated `BuildRuntime`, `Runtime`, `Scopes` enums with new values
+* Updated `BuildRuntime`, `Runtime` enums with `dart-3.11` and `flutter-3.41`
+* Updated `Scopes` enum with `KeysRead`, `KeysWrite`, `PlatformsRead`, `PlatformsWrite`
 * Updated `X-Appwrite-Response-Format` header to `1.9.1`
 * Updated TTL description for list caching in Databases and TablesDB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 3.0.0
+
+* [BREAKING] Renamed Webhook model fields: `security` → `tls`, `httpUser` → `authUsername`, `httpPass` → `authPassword`, `signatureKey` → `secret`
+* [BREAKING] Renamed Webhook service parameters to match: `security` → `tls`, `httpUser` → `authUsername`, `httpPass` → `authPassword`
+* Added `secret` parameter to Webhook create and update methods
+* Added `x` OAuth provider to `OAuthProvider` enum
+* Added `userType` field to `Log` model
+* Added `purge` parameter to `updateCollection` and `updateTable` for cache invalidation
+* Added Project service: platform CRUD, key CRUD, protocol/service status management
+* Added new models: `Key`, `KeyList`, `PlatformAndroid`, `PlatformApple`, `PlatformLinux`, `PlatformList`, and others
+* Added new enums: `PlatformType`, `ProtocolId`, `ServiceId`
+* Updated `BuildRuntime`, `Runtime`, `Scopes` enums with new values
+* Updated `X-Appwrite-Response-Format` header to `1.9.1`
+* Updated TTL description for list caching in Databases and TablesDB
+
 ## 2.0.0
 
 * [BREAKING] Changed `$sequence` type from `int` to `string` for rows and documents

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Appwrite .NET SDK
 
 ![License](https://img.shields.io/github/license/appwrite/sdk-for-dotnet.svg?style=flat-square)
-![Version](https://img.shields.io/badge/api%20version-1.9.0-blue.svg?style=flat-square)
+![Version](https://img.shields.io/badge/api%20version-1.9.1-blue.svg?style=flat-square)
 [![Build Status](https://img.shields.io/travis/com/appwrite/sdk-generator?style=flat-square)](https://travis-ci.com/appwrite/sdk-generator)
 [![Twitter Account](https://img.shields.io/twitter/follow/appwrite?color=00acee&label=twitter&style=flat-square)](https://twitter.com/appwrite)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord)
@@ -17,17 +17,17 @@ Appwrite is an open-source backend as a service server that abstracts and simpli
 Add this reference to your project's `.csproj` file:
 
 ```xml
-<PackageReference Include="Appwrite" Version="2.0.0" />
+<PackageReference Include="Appwrite" Version="3.0.0" />
 ```
 
 You can install packages from the command line:
 
 ```powershell
 # Package Manager
-Install-Package Appwrite -Version 2.0.0
+Install-Package Appwrite -Version 3.0.0
 
 # or .NET CLI
-dotnet add package Appwrite --version 2.0.0
+dotnet add package Appwrite --version 3.0.0
 ```
 
 

--- a/docs/examples/databases/create-datetime-attribute.md
+++ b/docs/examples/databases/create-datetime-attribute.md
@@ -15,6 +15,6 @@ AttributeDatetime result = await databases.CreateDatetimeAttribute(
     collectionId: "<COLLECTION_ID>",
     key: "",
     required: false,
-    default: "", // optional
+    default: "2020-10-15T06:38:00.000+00:00", // optional
     array: false // optional
 );```

--- a/docs/examples/databases/get-attribute.md
+++ b/docs/examples/databases/get-attribute.md
@@ -10,7 +10,7 @@ Client client = new Client()
 
 Databases databases = new Databases(client);
 
-AttributeBoolean result = await databases.GetAttribute(
+object result = await databases.GetAttribute(
     databaseId: "<DATABASE_ID>",
     collectionId: "<COLLECTION_ID>",
     key: ""

--- a/docs/examples/databases/update-collection.md
+++ b/docs/examples/databases/update-collection.md
@@ -16,5 +16,6 @@ Collection result = await databases.UpdateCollection(
     name: "<NAME>", // optional
     permissions: new List<string> { Permission.Read(Role.Any()) }, // optional
     documentSecurity: false, // optional
-    enabled: false // optional
+    enabled: false, // optional
+    purge: false // optional
 );```

--- a/docs/examples/databases/update-datetime-attribute.md
+++ b/docs/examples/databases/update-datetime-attribute.md
@@ -15,6 +15,6 @@ AttributeDatetime result = await databases.UpdateDatetimeAttribute(
     collectionId: "<COLLECTION_ID>",
     key: "",
     required: false,
-    default: "",
+    default: "2020-10-15T06:38:00.000+00:00",
     newKey: "" // optional
 );```

--- a/docs/examples/messaging/create-email.md
+++ b/docs/examples/messaging/create-email.md
@@ -22,5 +22,5 @@ Message result = await messaging.CreateEmail(
     attachments: new List<string>(), // optional
     draft: false, // optional
     html: false, // optional
-    scheduledAt: "" // optional
+    scheduledAt: "2020-10-15T06:38:00.000+00:00" // optional
 );```

--- a/docs/examples/messaging/create-push.md
+++ b/docs/examples/messaging/create-push.md
@@ -27,7 +27,7 @@ Message result = await messaging.CreatePush(
     tag: "<TAG>", // optional
     badge: 0, // optional
     draft: false, // optional
-    scheduledAt: "", // optional
+    scheduledAt: "2020-10-15T06:38:00.000+00:00", // optional
     contentAvailable: false, // optional
     critical: false, // optional
     priority: MessagePriority.Normal // optional

--- a/docs/examples/messaging/create-sms.md
+++ b/docs/examples/messaging/create-sms.md
@@ -17,5 +17,5 @@ Message result = await messaging.CreateSMS(
     users: new List<string>(), // optional
     targets: new List<string>(), // optional
     draft: false, // optional
-    scheduledAt: "" // optional
+    scheduledAt: "2020-10-15T06:38:00.000+00:00" // optional
 );```

--- a/docs/examples/messaging/update-email.md
+++ b/docs/examples/messaging/update-email.md
@@ -21,6 +21,6 @@ Message result = await messaging.UpdateEmail(
     html: false, // optional
     cc: new List<string>(), // optional
     bcc: new List<string>(), // optional
-    scheduledAt: "", // optional
+    scheduledAt: "2020-10-15T06:38:00.000+00:00", // optional
     attachments: new List<string>() // optional
 );```

--- a/docs/examples/messaging/update-push.md
+++ b/docs/examples/messaging/update-push.md
@@ -27,7 +27,7 @@ Message result = await messaging.UpdatePush(
     tag: "<TAG>", // optional
     badge: 0, // optional
     draft: false, // optional
-    scheduledAt: "", // optional
+    scheduledAt: "2020-10-15T06:38:00.000+00:00", // optional
     contentAvailable: false, // optional
     critical: false, // optional
     priority: MessagePriority.Normal // optional

--- a/docs/examples/messaging/update-sms.md
+++ b/docs/examples/messaging/update-sms.md
@@ -17,5 +17,5 @@ Message result = await messaging.UpdateSMS(
     targets: new List<string>(), // optional
     content: "<CONTENT>", // optional
     draft: false, // optional
-    scheduledAt: "" // optional
+    scheduledAt: "2020-10-15T06:38:00.000+00:00" // optional
 );```

--- a/docs/examples/project/create-android-platform.md
+++ b/docs/examples/project/create-android-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformAndroid result = await project.CreateAndroidPlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    applicationId: "<APPLICATION_ID>"
+);```

--- a/docs/examples/project/create-apple-platform.md
+++ b/docs/examples/project/create-apple-platform.md
@@ -8,8 +8,10 @@ Client client = new Client()
     .SetProject("<YOUR_PROJECT_ID>") // Your project ID
     .SetKey("<YOUR_API_KEY>"); // Your secret API key
 
-Webhooks webhooks = new Webhooks(client);
+Project project = new Project(client);
 
-Webhook result = await webhooks.UpdateSignature(
-    webhookId: "<WEBHOOK_ID>"
+PlatformApple result = await project.CreateApplePlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    bundleIdentifier: "<BUNDLE_IDENTIFIER>"
 );```

--- a/docs/examples/project/create-key.md
+++ b/docs/examples/project/create-key.md
@@ -1,0 +1,19 @@
+```csharp
+using Appwrite;
+using Appwrite.Enums;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+Key result = await project.CreateKey(
+    keyId: "<KEY_ID>",
+    name: "<NAME>",
+    scopes: new List&lt;Scopes&gt; { Scopes.SessionsWrite },
+    expire: "2020-10-15T06:38:00.000+00:00" // optional
+);```

--- a/docs/examples/project/create-linux-platform.md
+++ b/docs/examples/project/create-linux-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformLinux result = await project.CreateLinuxPlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    packageName: "<PACKAGE_NAME>"
+);```

--- a/docs/examples/project/create-web-platform.md
+++ b/docs/examples/project/create-web-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformWeb result = await project.CreateWebPlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    hostname: "app.example.com"
+);```

--- a/docs/examples/project/create-windows-platform.md
+++ b/docs/examples/project/create-windows-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformWindows result = await project.CreateWindowsPlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    packageIdentifierName: "<PACKAGE_IDENTIFIER_NAME>"
+);```

--- a/docs/examples/project/delete-key.md
+++ b/docs/examples/project/delete-key.md
@@ -1,0 +1,15 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+await project.DeleteKey(
+    keyId: "<KEY_ID>"
+);```

--- a/docs/examples/project/delete-platform.md
+++ b/docs/examples/project/delete-platform.md
@@ -1,0 +1,15 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+await project.DeletePlatform(
+    platformId: "<PLATFORM_ID>"
+);```

--- a/docs/examples/project/get-key.md
+++ b/docs/examples/project/get-key.md
@@ -1,0 +1,15 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+Key result = await project.GetKey(
+    keyId: "<KEY_ID>"
+);```

--- a/docs/examples/project/get-platform.md
+++ b/docs/examples/project/get-platform.md
@@ -1,0 +1,15 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+object result = await project.GetPlatform(
+    platformId: "<PLATFORM_ID>"
+);```

--- a/docs/examples/project/list-keys.md
+++ b/docs/examples/project/list-keys.md
@@ -1,0 +1,16 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+KeyList result = await project.ListKeys(
+    queries: new List<string>(), // optional
+    total: false // optional
+);```

--- a/docs/examples/project/list-platforms.md
+++ b/docs/examples/project/list-platforms.md
@@ -1,0 +1,16 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformList result = await project.ListPlatforms(
+    queries: new List<string>(), // optional
+    total: false // optional
+);```

--- a/docs/examples/project/update-android-platform.md
+++ b/docs/examples/project/update-android-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformAndroid result = await project.UpdateAndroidPlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    applicationId: "<APPLICATION_ID>"
+);```

--- a/docs/examples/project/update-apple-platform.md
+++ b/docs/examples/project/update-apple-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformApple result = await project.UpdateApplePlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    bundleIdentifier: "<BUNDLE_IDENTIFIER>"
+);```

--- a/docs/examples/project/update-key.md
+++ b/docs/examples/project/update-key.md
@@ -1,0 +1,19 @@
+```csharp
+using Appwrite;
+using Appwrite.Enums;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+Key result = await project.UpdateKey(
+    keyId: "<KEY_ID>",
+    name: "<NAME>",
+    scopes: new List&lt;Scopes&gt; { Scopes.SessionsWrite },
+    expire: "2020-10-15T06:38:00.000+00:00" // optional
+);```

--- a/docs/examples/project/update-labels.md
+++ b/docs/examples/project/update-labels.md
@@ -1,0 +1,15 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+Project result = await project.UpdateLabels(
+    labels: new List<string>()
+);```

--- a/docs/examples/project/update-linux-platform.md
+++ b/docs/examples/project/update-linux-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformLinux result = await project.UpdateLinuxPlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    packageName: "<PACKAGE_NAME>"
+);```

--- a/docs/examples/project/update-protocol-status.md
+++ b/docs/examples/project/update-protocol-status.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Enums;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+Project result = await project.UpdateProtocolStatus(
+    protocolId: ProtocolId.Rest,
+    enabled: false
+);```

--- a/docs/examples/project/update-service-status.md
+++ b/docs/examples/project/update-service-status.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Enums;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+Project result = await project.UpdateServiceStatus(
+    serviceId: ServiceId.Account,
+    enabled: false
+);```

--- a/docs/examples/project/update-web-platform.md
+++ b/docs/examples/project/update-web-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformWeb result = await project.UpdateWebPlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    hostname: "app.example.com"
+);```

--- a/docs/examples/project/update-windows-platform.md
+++ b/docs/examples/project/update-windows-platform.md
@@ -1,0 +1,17 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Project project = new Project(client);
+
+PlatformWindows result = await project.UpdateWindowsPlatform(
+    platformId: "<PLATFORM_ID>",
+    name: "<NAME>",
+    packageIdentifierName: "<PACKAGE_IDENTIFIER_NAME>"
+);```

--- a/docs/examples/tablesdb/create-datetime-column.md
+++ b/docs/examples/tablesdb/create-datetime-column.md
@@ -15,6 +15,6 @@ ColumnDatetime result = await tablesDB.CreateDatetimeColumn(
     tableId: "<TABLE_ID>",
     key: "",
     required: false,
-    default: "", // optional
+    default: "2020-10-15T06:38:00.000+00:00", // optional
     array: false // optional
 );```

--- a/docs/examples/tablesdb/get-column.md
+++ b/docs/examples/tablesdb/get-column.md
@@ -10,7 +10,7 @@ Client client = new Client()
 
 TablesDB tablesDB = new TablesDB(client);
 
-ColumnBoolean result = await tablesDB.GetColumn(
+object result = await tablesDB.GetColumn(
     databaseId: "<DATABASE_ID>",
     tableId: "<TABLE_ID>",
     key: ""

--- a/docs/examples/tablesdb/update-datetime-column.md
+++ b/docs/examples/tablesdb/update-datetime-column.md
@@ -15,6 +15,6 @@ ColumnDatetime result = await tablesDB.UpdateDatetimeColumn(
     tableId: "<TABLE_ID>",
     key: "",
     required: false,
-    default: "",
+    default: "2020-10-15T06:38:00.000+00:00",
     newKey: "" // optional
 );```

--- a/docs/examples/tablesdb/update-table.md
+++ b/docs/examples/tablesdb/update-table.md
@@ -16,5 +16,6 @@ Table result = await tablesDB.UpdateTable(
     name: "<NAME>", // optional
     permissions: new List<string> { Permission.Read(Role.Any()) }, // optional
     rowSecurity: false, // optional
-    enabled: false // optional
+    enabled: false, // optional
+    purge: false // optional
 );```

--- a/docs/examples/tokens/create-file-token.md
+++ b/docs/examples/tokens/create-file-token.md
@@ -13,5 +13,5 @@ Tokens tokens = new Tokens(client);
 ResourceToken result = await tokens.CreateFileToken(
     bucketId: "<BUCKET_ID>",
     fileId: "<FILE_ID>",
-    expire: "" // optional
+    expire: "2020-10-15T06:38:00.000+00:00" // optional
 );```

--- a/docs/examples/tokens/update.md
+++ b/docs/examples/tokens/update.md
@@ -12,5 +12,5 @@ Tokens tokens = new Tokens(client);
 
 ResourceToken result = await tokens.Update(
     tokenId: "<TOKEN_ID>",
-    expire: "" // optional
+    expire: "2020-10-15T06:38:00.000+00:00" // optional
 );```

--- a/docs/examples/webhooks/create.md
+++ b/docs/examples/webhooks/create.md
@@ -16,7 +16,8 @@ Webhook result = await webhooks.Create(
     name: "<NAME>",
     events: new List<string>(),
     enabled: false, // optional
-    security: false, // optional
-    httpUser: "<HTTP_USER>", // optional
-    httpPass: "<HTTP_PASS>" // optional
+    tls: false, // optional
+    authUsername: "<AUTH_USERNAME>", // optional
+    authPassword: "<AUTH_PASSWORD>", // optional
+    secret: "<SECRET>" // optional
 );```

--- a/docs/examples/webhooks/update-secret.md
+++ b/docs/examples/webhooks/update-secret.md
@@ -1,0 +1,16 @@
+```csharp
+using Appwrite;
+using Appwrite.Models;
+using Appwrite.Services;
+
+Client client = new Client()
+    .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
+    .SetProject("<YOUR_PROJECT_ID>") // Your project ID
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
+
+Webhooks webhooks = new Webhooks(client);
+
+Webhook result = await webhooks.UpdateSecret(
+    webhookId: "<WEBHOOK_ID>",
+    secret: "<SECRET>" // optional
+);```

--- a/docs/examples/webhooks/update.md
+++ b/docs/examples/webhooks/update.md
@@ -16,7 +16,7 @@ Webhook result = await webhooks.Update(
     url: "",
     events: new List<string>(),
     enabled: false, // optional
-    security: false, // optional
-    httpUser: "<HTTP_USER>", // optional
-    httpPass: "<HTTP_PASS>" // optional
+    tls: false, // optional
+    authUsername: "<AUTH_USERNAME>", // optional
+    authPassword: "<AUTH_PASSWORD>" // optional
 );```


### PR DESCRIPTION
This PR contains updates to the .NET SDK for version 3.0.0.

## What's Changed

* [BREAKING] Renamed Webhook model fields: `security` → `tls`, `httpUser` → `authUsername`, `httpPass` → `authPassword`, `signatureKey` → `secret`
* [BREAKING] Renamed Webhook service parameters to match: `security` → `tls`, `httpUser` → `authUsername`, `httpPass` → `authPassword`
* [BREAKING] Renamed `Webhooks.UpdateSignature()` to `Webhooks.UpdateSecret()` with new optional `secret` parameter
* Added `Client.GetHeaders()` method to retrieve request headers
* Added `secret` parameter to Webhook create and update methods
* Added `x` OAuth provider to `OAuthProvider` enum
* Added `userType` field to `Log` model
* Added `purge` parameter to `UpdateCollection` and `UpdateTable` for cache invalidation
* Added Project service: platform CRUD, key CRUD, protocol/service status management
* Added new models: `Key`, `KeyList`, `Project`, `DevKey`, `MockNumber`, `AuthProvider`, `PlatformAndroid`, `PlatformApple`, `PlatformLinux`, `PlatformList`, `PlatformWeb`, `PlatformWindows`, `BillingLimits`, `Block`
* Added new enums: `PlatformType`, `ProtocolId`, `ServiceId`
* Updated `BuildRuntime`, `Runtime` enums with `dart-3.11` and `flutter-3.41`
* Updated `Scopes` enum with `KeysRead`, `KeysWrite`, `PlatformsRead`, `PlatformsWrite`
* Updated `X-Appwrite-Response-Format` header to `1.9.1`
* Updated TTL description for list caching in Databases and TablesDB