### PR TITLE
feat: .NET SDK update for version 4.1.0

### DIFF
--- a/Appwrite/Appwrite.csproj
+++ b/Appwrite/Appwrite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageId>Appwrite</PackageId>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <Authors>Appwrite Team</Authors>
     <Company>Appwrite Team</Company>
     <Description>

--- a/Appwrite/Appwrite.csproj
+++ b/Appwrite/Appwrite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageId>Appwrite</PackageId>
-    <Version>4.0.1</Version>
+    <Version>4.1.0</Version>
     <Authors>Appwrite Team</Authors>
     <Company>Appwrite Team</Company>
     <Description>

--- a/Appwrite/Client.cs
+++ b/Appwrite/Client.cs
@@ -69,11 +69,11 @@ namespace Appwrite
             _headers = new Dictionary<string, string>()
             {
                 { "content-type", "application/json" },
-                { "user-agent" , $"AppwriteDotNetSDK/4.0.0 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
+                { "user-agent" , $"AppwriteDotNetSDK/4.0.1 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
                 { "x-sdk-name", ".NET" },
                 { "x-sdk-platform", "server" },
                 { "x-sdk-language", "dotnet" },
-                { "x-sdk-version", "4.0.0"},
+                { "x-sdk-version", "4.0.1"},
                 { "X-Appwrite-Response-Format", "1.9.5" }
             };
 

--- a/Appwrite/Client.cs
+++ b/Appwrite/Client.cs
@@ -69,11 +69,11 @@ namespace Appwrite
             _headers = new Dictionary<string, string>()
             {
                 { "content-type", "application/json" },
-                { "user-agent" , $"AppwriteDotNetSDK/4.0.1 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
+                { "user-agent" , $"AppwriteDotNetSDK/4.1.0 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
                 { "x-sdk-name", ".NET" },
                 { "x-sdk-platform", "server" },
                 { "x-sdk-language", "dotnet" },
-                { "x-sdk-version", "4.0.1"},
+                { "x-sdk-version", "4.1.0"},
                 { "X-Appwrite-Response-Format", "1.9.5" }
             };
 

--- a/Appwrite/Enums/BuildRuntime.cs
+++ b/Appwrite/Enums/BuildRuntime.cs
@@ -42,6 +42,9 @@ namespace Appwrite.Enums
         public static BuildRuntime PythonMl311 => new BuildRuntime("python-ml-3.11");
         public static BuildRuntime PythonMl312 => new BuildRuntime("python-ml-3.12");
         public static BuildRuntime PythonMl313 => new BuildRuntime("python-ml-3.13");
+        public static BuildRuntime Deno121 => new BuildRuntime("deno-1.21");
+        public static BuildRuntime Deno124 => new BuildRuntime("deno-1.24");
+        public static BuildRuntime Deno135 => new BuildRuntime("deno-1.35");
         public static BuildRuntime Deno140 => new BuildRuntime("deno-1.40");
         public static BuildRuntime Deno146 => new BuildRuntime("deno-1.46");
         public static BuildRuntime Deno20 => new BuildRuntime("deno-2.0");

--- a/Appwrite/Enums/Runtime.cs
+++ b/Appwrite/Enums/Runtime.cs
@@ -42,6 +42,9 @@ namespace Appwrite.Enums
         public static Runtime PythonMl311 => new Runtime("python-ml-3.11");
         public static Runtime PythonMl312 => new Runtime("python-ml-3.12");
         public static Runtime PythonMl313 => new Runtime("python-ml-3.13");
+        public static Runtime Deno121 => new Runtime("deno-1.21");
+        public static Runtime Deno124 => new Runtime("deno-1.24");
+        public static Runtime Deno135 => new Runtime("deno-1.35");
         public static Runtime Deno140 => new Runtime("deno-1.40");
         public static Runtime Deno146 => new Runtime("deno-1.46");
         public static Runtime Deno20 => new Runtime("deno-2.0");

--- a/Appwrite/Models/BillingLimits.cs
+++ b/Appwrite/Models/BillingLimits.cs
@@ -12,38 +12,38 @@ namespace Appwrite.Models
     public class BillingLimits
     {
         [JsonPropertyName("bandwidth")]
-        public long Bandwidth { get; private set; }
+        public long? Bandwidth { get; private set; }
 
         [JsonPropertyName("storage")]
-        public long Storage { get; private set; }
+        public long? Storage { get; private set; }
 
         [JsonPropertyName("users")]
-        public long Users { get; private set; }
+        public long? Users { get; private set; }
 
         [JsonPropertyName("executions")]
-        public long Executions { get; private set; }
+        public long? Executions { get; private set; }
 
         [JsonPropertyName("GBHours")]
-        public long GBHours { get; private set; }
+        public long? GBHours { get; private set; }
 
         [JsonPropertyName("imageTransformations")]
-        public long ImageTransformations { get; private set; }
+        public long? ImageTransformations { get; private set; }
 
         [JsonPropertyName("authPhone")]
-        public long AuthPhone { get; private set; }
+        public long? AuthPhone { get; private set; }
 
         [JsonPropertyName("budgetLimit")]
-        public long BudgetLimit { get; private set; }
+        public long? BudgetLimit { get; private set; }
 
         public BillingLimits(
-            long bandwidth,
-            long storage,
-            long users,
-            long executions,
-            long gBHours,
-            long imageTransformations,
-            long authPhone,
-            long budgetLimit
+            long? bandwidth,
+            long? storage,
+            long? users,
+            long? executions,
+            long? gBHours,
+            long? imageTransformations,
+            long? authPhone,
+            long? budgetLimit
         )
         {
             Bandwidth = bandwidth;
@@ -57,14 +57,14 @@ namespace Appwrite.Models
         }
 
         public static BillingLimits From(Dictionary<string, object> map) => new BillingLimits(
-            bandwidth: Convert.ToInt64(map["bandwidth"]),
-            storage: Convert.ToInt64(map["storage"]),
-            users: Convert.ToInt64(map["users"]),
-            executions: Convert.ToInt64(map["executions"]),
-            gBHours: Convert.ToInt64(map["GBHours"]),
-            imageTransformations: Convert.ToInt64(map["imageTransformations"]),
-            authPhone: Convert.ToInt64(map["authPhone"]),
-            budgetLimit: Convert.ToInt64(map["budgetLimit"])
+            bandwidth: map["bandwidth"] == null ? null : Convert.ToInt64(map["bandwidth"]),
+            storage: map["storage"] == null ? null : Convert.ToInt64(map["storage"]),
+            users: map["users"] == null ? null : Convert.ToInt64(map["users"]),
+            executions: map["executions"] == null ? null : Convert.ToInt64(map["executions"]),
+            gBHours: map["GBHours"] == null ? null : Convert.ToInt64(map["GBHours"]),
+            imageTransformations: map["imageTransformations"] == null ? null : Convert.ToInt64(map["imageTransformations"]),
+            authPhone: map["authPhone"] == null ? null : Convert.ToInt64(map["authPhone"]),
+            budgetLimit: map["budgetLimit"] == null ? null : Convert.ToInt64(map["budgetLimit"])
         );
 
         public Dictionary<string, object?> ToMap() => new Dictionary<string, object?>()

--- a/Appwrite/Models/File.cs
+++ b/Appwrite/Models/File.cs
@@ -38,6 +38,9 @@ namespace Appwrite.Models
         [JsonPropertyName("sizeOriginal")]
         public long SizeOriginal { get; private set; }
 
+        [JsonPropertyName("sizeActual")]
+        public long SizeActual { get; private set; }
+
         [JsonPropertyName("chunksTotal")]
         public long ChunksTotal { get; private set; }
 
@@ -60,6 +63,7 @@ namespace Appwrite.Models
             string signature,
             string mimeType,
             long sizeOriginal,
+            long sizeActual,
             long chunksTotal,
             long chunksUploaded,
             bool encryption,
@@ -75,6 +79,7 @@ namespace Appwrite.Models
             Signature = signature;
             MimeType = mimeType;
             SizeOriginal = sizeOriginal;
+            SizeActual = sizeActual;
             ChunksTotal = chunksTotal;
             ChunksUploaded = chunksUploaded;
             Encryption = encryption;
@@ -91,6 +96,7 @@ namespace Appwrite.Models
             signature: map["signature"].ToString(),
             mimeType: map["mimeType"].ToString(),
             sizeOriginal: Convert.ToInt64(map["sizeOriginal"]),
+            sizeActual: Convert.ToInt64(map["sizeActual"]),
             chunksTotal: Convert.ToInt64(map["chunksTotal"]),
             chunksUploaded: Convert.ToInt64(map["chunksUploaded"]),
             encryption: (bool)map["encryption"],
@@ -108,6 +114,7 @@ namespace Appwrite.Models
             { "signature", Signature },
             { "mimeType", MimeType },
             { "sizeOriginal", SizeOriginal },
+            { "sizeActual", SizeActual },
             { "chunksTotal", ChunksTotal },
             { "chunksUploaded", ChunksUploaded },
             { "encryption", Encryption },

--- a/Appwrite/Models/Project.cs
+++ b/Appwrite/Models/Project.cs
@@ -84,7 +84,7 @@ namespace Appwrite.Models
         public string Region { get; private set; }
 
         [JsonPropertyName("billingLimits")]
-        public BillingLimits BillingLimits { get; private set; }
+        public BillingLimits? BillingLimits { get; private set; }
 
         [JsonPropertyName("blocks")]
         public List<Block> Blocks { get; private set; }
@@ -117,7 +117,7 @@ namespace Appwrite.Models
             List<ProjectService> services,
             List<ProjectProtocol> protocols,
             string region,
-            BillingLimits billingLimits,
+            BillingLimits? billingLimits,
             List<Block> blocks,
             string consoleAccessedAt
         )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change Log
 
-## 4.0.1
+## 4.1.0
 
-* Fixed: `BillingLimits` inner fields and `Project.billingLimits` are now optional — server emits sparse "limits crossed" map
-* Fixed: `Project.consoleAccessedAt` defaults to empty string for never-accessed projects (no longer null)
-* Added: `File.sizeActual` field — actual bytes used on disk after compression / encryption
-* Updated: `BuildRuntime` and `Runtime` enums with `deno-1.21`, `deno-1.24`, and `deno-1.35`
-* Updated: Advisor doc examples corrected to use API key auth instead of session
+* Added `Deno121`, `Deno124`, and `Deno135` runtime support to `BuildRuntime` and `Runtime` enums
+* Added `SizeActual` property to `File` model for tracking actual file sizes
+* Breaking: Changed `BillingLimits` properties to nullable types in constructor and model
+* Breaking: Changed `BillingLimits` property to nullable in `Project` model
+* Updated advisor authentication examples to use API key instead of session
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 4.0.1
+
+* Fixed: `BillingLimits` inner fields and `Project.billingLimits` are now optional — server emits sparse "limits crossed" map
+* Fixed: `Project.consoleAccessedAt` defaults to empty string for never-accessed projects (no longer null)
+* Added: `File.sizeActual` field — actual bytes used on disk after compression / encryption
+* Updated: `BuildRuntime` and `Runtime` enums with `deno-1.21`, `deno-1.24`, and `deno-1.35`
+* Updated: Advisor doc examples corrected to use API key auth instead of session
+
 ## 4.0.0
 
 * Breaking: Renamed `AuthMethod` enum to `ProjectAuthMethodId`

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Appwrite is an open-source backend as a service server that abstracts and simpli
 Add this reference to your project's `.csproj` file:
 
 ```xml
-<PackageReference Include="Appwrite" Version="4.0.1" />
+<PackageReference Include="Appwrite" Version="4.1.0" />
 ```
 
 You can install packages from the command line:
 
 ```powershell
 # Package Manager
-Install-Package Appwrite -Version 4.0.1
+Install-Package Appwrite -Version 4.1.0
 
 # or .NET CLI
-dotnet add package Appwrite --version 4.0.1
+dotnet add package Appwrite --version 4.1.0
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Appwrite is an open-source backend as a service server that abstracts and simpli
 Add this reference to your project's `.csproj` file:
 
 ```xml
-<PackageReference Include="Appwrite" Version="4.0.0" />
+<PackageReference Include="Appwrite" Version="4.0.1" />
 ```
 
 You can install packages from the command line:
 
 ```powershell
 # Package Manager
-Install-Package Appwrite -Version 4.0.0
+Install-Package Appwrite -Version 4.0.1
 
 # or .NET CLI
-dotnet add package Appwrite --version 4.0.0
+dotnet add package Appwrite --version 4.0.1
 ```
 
 

--- a/docs/examples/advisor/get-insight.md
+++ b/docs/examples/advisor/get-insight.md
@@ -6,7 +6,7 @@ using Appwrite.Services;
 Client client = new Client()
     .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
     .SetProject("<YOUR_PROJECT_ID>") // Your project ID
-    .SetSession(""); // The user session to authenticate with
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
 
 Advisor advisor = new Advisor(client);
 

--- a/docs/examples/advisor/get-report.md
+++ b/docs/examples/advisor/get-report.md
@@ -6,7 +6,7 @@ using Appwrite.Services;
 Client client = new Client()
     .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
     .SetProject("<YOUR_PROJECT_ID>") // Your project ID
-    .SetSession(""); // The user session to authenticate with
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
 
 Advisor advisor = new Advisor(client);
 

--- a/docs/examples/advisor/list-insights.md
+++ b/docs/examples/advisor/list-insights.md
@@ -6,7 +6,7 @@ using Appwrite.Services;
 Client client = new Client()
     .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
     .SetProject("<YOUR_PROJECT_ID>") // Your project ID
-    .SetSession(""); // The user session to authenticate with
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
 
 Advisor advisor = new Advisor(client);
 

--- a/docs/examples/advisor/list-reports.md
+++ b/docs/examples/advisor/list-reports.md
@@ -6,7 +6,7 @@ using Appwrite.Services;
 Client client = new Client()
     .SetEndPoint("https://<REGION>.cloud.appwrite.io/v1") // Your API Endpoint
     .SetProject("<YOUR_PROJECT_ID>") // Your project ID
-    .SetSession(""); // The user session to authenticate with
+    .SetKey("<YOUR_API_KEY>"); // Your secret API key
 
 Advisor advisor = new Advisor(client);
 


### PR DESCRIPTION
This PR contains updates to the .NET SDK for version 4.1.0.

## Changes

* Added `Deno121`, `Deno124`, and `Deno135` runtime support to `BuildRuntime` and `Runtime` enums
* Added `SizeActual` property to `File` model for tracking actual file sizes
* Breaking: Changed `BillingLimits` properties to nullable types in constructor and model
* Breaking: Changed `BillingLimits` property to nullable in `Project` model
* Updated advisor authentication examples to use API key instead of session