### PR TITLE
chore: bump SDK version to 4.2.0

### DIFF
--- a/Appwrite/Appwrite.csproj
+++ b/Appwrite/Appwrite.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <PackageId>Appwrite</PackageId>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <Authors>Appwrite Team</Authors>
     <Company>Appwrite Team</Company>
     <Description>

--- a/Appwrite/Client.cs
+++ b/Appwrite/Client.cs
@@ -71,11 +71,11 @@ namespace Appwrite
             _headers = new Dictionary<string, string>()
             {
                 { "content-type", "application/json" },
-                { "user-agent" , $"AppwriteDotNetSDK/4.1.0 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
+                { "user-agent" , $"AppwriteDotNetSDK/4.2.0 ({Environment.OSVersion.Platform}; {Environment.OSVersion.VersionString})"},
                 { "x-sdk-name", ".NET" },
                 { "x-sdk-platform", "server" },
                 { "x-sdk-language", "dotnet" },
-                { "x-sdk-version", "4.1.0"},
+                { "x-sdk-version", "4.2.0"},
                 { "X-Appwrite-Response-Format", "1.9.5" }
             };
 

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Appwrite is an open-source backend as a service server that abstracts and simpli
 Add this reference to your project's `.csproj` file:
 
 ```xml
-<PackageReference Include="Appwrite" Version="4.1.0" />
+<PackageReference Include="Appwrite" Version="4.2.0" />
 ```
 
 You can install packages from the command line:
 
 ```powershell
 # Package Manager
-Install-Package Appwrite -Version 4.1.0
+Install-Package Appwrite -Version 4.2.0
 
 # or .NET CLI
-dotnet add package Appwrite --version 4.1.0
+dotnet add package Appwrite --version 4.2.0
 ```
 
 


### PR DESCRIPTION
This PR bumps SDK version metadata to 4.2.0 after the concurrent chunk upload update.